### PR TITLE
♻ | Arrumando problemas no comando mcstatus...

### DIFF
--- a/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McStatusCommand.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McStatusCommand.kt
@@ -15,7 +15,7 @@ class McStatusCommand : AbstractCommand("mcstatus", category = CommandCategory.M
     }
 
     override fun run(context: CommandContext, locale: BaseLocale) {
-        var body = HttpRequest.get("https://mcapi.ca/mcstatus").body();
+        var body = HttpRequest.get("https://use.gameapis.net/mc/extra/status").body();
 
         var builder = EmbedBuilder()
                 .setTitle("📡 ${locale["MCSTATUS_MOJANG_STATUS"]}", "https://help.mojang.com/")


### PR DESCRIPTION
🤷 Como a API do site atual do comando "+mcstatus" está migrando, vamos migrar com ela!

-  Removido suporte ao MCAPI (https://mcapi.ca/mcstatus)

- Adicionado suporte ao GameAPIs (https://use.gameapis.net/mc/extra/status)