### PR TITLE
Support MediaWiki Atom feeds

### DIFF
--- a/src/main/java/com/mrpowergamerbr/loritta/website/views/subviews/api/APIGetRssFeedTitleView.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/website/views/subviews/api/APIGetRssFeedTitleView.kt
@@ -67,6 +67,8 @@ class APIGetRssFeedTitleView : NoVarsView() {
 				description = jsoup.select("feed entry description").first().text()
 			} else if (jsoup.select("feed entry content").isNotEmpty()) {
 				description = jsoup.select("feed entry content").first().text()
+			} else if (jsoup.select("feed entry summary").isNotEmpty()) {
+				description = jsoup.select("feed entry summary").first().text()
 			}
 		} else if (jsoup.select("rdf|RDF").attr("xmlns") == "http://purl.org/rss/1.0/") {
 			// RDF Feed (usada pela Steam)


### PR DESCRIPTION
Hi.

This PR should solve issues with Loritta not able to read Atom feeds of MediaWiki-based websites (Like Wikipedia). An example would be [Recent Changes Atom](https://en.wikipedia.org/w/api.php?hidebots=1&hidecategorization=1&hideWikibase=1&urlversion=1&days=7&limit=50&target=Main_Page&action=feedrecentchanges&feedformat=atom).

With this change, `summary` tag should be accepted as `{description}`.

Please notify me when you're able to push this change to the running version.

Best Regards