### PR TITLE
Adicionar sistema de plugins

### DIFF
--- a/src/main/java/com/mrpowergamerbr/loritta/Loritta.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/Loritta.kt
@@ -22,6 +22,7 @@ import com.mrpowergamerbr.loritta.listeners.*
 import com.mrpowergamerbr.loritta.livestreams.TwitchAPI
 import com.mrpowergamerbr.loritta.modules.ServerSupportModule
 import com.mrpowergamerbr.loritta.network.Databases
+import com.mrpowergamerbr.loritta.plugin.PluginManager
 import com.mrpowergamerbr.loritta.tables.*
 import com.mrpowergamerbr.loritta.threads.NewLivestreamThread
 import com.mrpowergamerbr.loritta.threads.RaffleThread
@@ -156,6 +157,7 @@ class Loritta(config: LorittaConfig) {
 	var premiumKeys = mutableListOf<PremiumKey>()
 	var blacklistedServers = mutableMapOf<String, String>()
 	val networkBanManager = LorittaNetworkBanManager()
+	var pluginManager = PluginManager()
 
 	var isPatreon = mutableMapOf<String, Boolean>()
 	var isDonator = mutableMapOf<String, Boolean>()
@@ -297,6 +299,7 @@ class Loritta(config: LorittaConfig) {
 		DebugLog.startCommandListenerThread()
 
 		loadCommandManager() // Inicie todos os comandos da Loritta
+		pluginManager.loadPlugins()
 
 		thread {
 			socket.start()

--- a/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/magic/PluginsCommand.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/magic/PluginsCommand.kt
@@ -28,6 +28,7 @@ class PluginsCommand : LorittaCommand(arrayOf("plugins"), category = CommandCate
 						"Carregando plugin `$pluginName.jar`..."
 				)
 		)
+
 		loritta.pluginManager.loadPlugin(File(Loritta.FOLDER, "plugins/$pluginName.jar"))
 		context.reply(
 				LoriReply(
@@ -71,7 +72,7 @@ class PluginsCommand : LorittaCommand(arrayOf("plugins"), category = CommandCate
 		if (plugin == null) {
 			context.reply(
 					LoriReply(
-							"Plugin não existe! Como você vai descarregar algo que não existe?"
+							"Plugin não existe! Como você vai recarregar algo que não existe?"
 					)
 			)
 			return

--- a/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/magic/PluginsCommand.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/magic/PluginsCommand.kt
@@ -1,0 +1,95 @@
+package com.mrpowergamerbr.loritta.commands.vanilla.magic
+
+import com.mrpowergamerbr.loritta.Loritta
+import com.mrpowergamerbr.loritta.commands.CommandCategory
+import com.mrpowergamerbr.loritta.utils.LoriReply
+import com.mrpowergamerbr.loritta.utils.loritta
+import net.perfectdreams.commands.annotation.Subcommand
+import net.perfectdreams.commands.loritta.LorittaCommand
+import net.perfectdreams.commands.loritta.LorittaCommandContext
+import java.io.File
+
+class PluginsCommand : LorittaCommand(arrayOf("plugins"), category = CommandCategory.MAGIC) {
+	override val onlyOwner = true
+
+	@Subcommand
+	suspend fun pluginList(context: LorittaCommandContext) {
+		context.reply(
+				LoriReply(
+						"**Plugins (${loritta.pluginManager.plugins.size}**: ${loritta.pluginManager.plugins.joinToString(", ", transform = { it.name })}"
+				)
+		)
+	}
+
+	@Subcommand(["load"])
+	suspend fun load(context: LorittaCommandContext, pluginName: String) {
+		context.reply(
+				LoriReply(
+						"Carregando plugin `$pluginName.jar`..."
+				)
+		)
+		loritta.pluginManager.loadPlugin(File(Loritta.FOLDER, "plugins/$pluginName.jar"))
+		context.reply(
+				LoriReply(
+						"Finalizado, yay!"
+				)
+		)
+	}
+
+	@Subcommand(["unload"])
+	suspend fun unload(context: LorittaCommandContext, pluginName: String) {
+		val plugin = loritta.pluginManager.getPlugin(pluginName)
+
+		if (plugin == null) {
+			context.reply(
+					LoriReply(
+							"Plugin não existe! Como você vai descarregar algo que não existe?"
+					)
+			)
+			return
+		}
+
+		context.reply(
+				LoriReply(
+						"Descarregando plugin `$pluginName.jar`..."
+				)
+		)
+
+		loritta.pluginManager.unloadPlugin(plugin)
+
+		context.reply(
+				LoriReply(
+						"Finalizado, yay!"
+				)
+		)
+	}
+
+	@Subcommand(["reload"])
+	suspend fun reload(context: LorittaCommandContext, pluginName: String) {
+		val plugin = loritta.pluginManager.getPlugin(pluginName)
+
+		if (plugin == null) {
+			context.reply(
+					LoriReply(
+							"Plugin não existe! Como você vai descarregar algo que não existe?"
+					)
+			)
+			return
+		}
+
+		context.reply(
+				LoriReply(
+						"Recarregando plugin `$pluginName.jar`..."
+				)
+		)
+
+		loritta.pluginManager.unloadPlugin(plugin)
+		loritta.pluginManager.loadPlugin(plugin.pluginFile)
+
+		context.reply(
+				LoriReply(
+						"Finalizado, yay!"
+				)
+		)
+	}
+}

--- a/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/magic/PluginsCommand.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/magic/PluginsCommand.kt
@@ -16,7 +16,7 @@ class PluginsCommand : LorittaCommand(arrayOf("plugins"), category = CommandCate
 	suspend fun pluginList(context: LorittaCommandContext) {
 		context.reply(
 				LoriReply(
-						"**Plugins (${loritta.pluginManager.plugins.size}**: ${loritta.pluginManager.plugins.joinToString(", ", transform = { it.name })}"
+						"**Plugins (${loritta.pluginManager.plugins.size}):** ${loritta.pluginManager.plugins.joinToString(", ", transform = { it.name })}"
 				)
 		)
 	}

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/InvalidPluginException.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/InvalidPluginException.kt
@@ -1,0 +1,3 @@
+package com.mrpowergamerbr.loritta.plugin
+
+class InvalidPluginException(override val message: String) : RuntimeException()

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
@@ -1,0 +1,25 @@
+package com.mrpowergamerbr.loritta.plugin
+
+import com.mrpowergamerbr.loritta.Loritta
+import com.mrpowergamerbr.loritta.utils.loritta
+import net.perfectdreams.commands.loritta.LorittaCommand
+import java.io.File
+import java.net.URLClassLoader
+
+open class LorittaPlugin(val name: String, val classLoader: URLClassLoader? = null) {
+	val commands = mutableListOf<LorittaCommand>()
+	val dataFolder = File(Loritta.FOLDER, "plugins/$name")
+
+	open fun onEnable() {
+
+	}
+
+	open fun onDisable() {
+
+	}
+
+	fun registerCommand(command: LorittaCommand) {
+		loritta.lorittaCommandManager.registerCommand(command)
+		commands.add(command)
+	}
+}

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
@@ -6,7 +6,11 @@ import net.perfectdreams.commands.loritta.LorittaCommand
 import java.io.File
 import java.net.URLClassLoader
 
-open class LorittaPlugin(val name: String, val classLoader: URLClassLoader, val pluginFile: File) {
+open class LorittaPlugin {
+	lateinit var name: String
+	lateinit var classLoader: URLClassLoader
+	lateinit var pluginFile: File
+
 	val commands = mutableListOf<LorittaCommand>()
 	val dataFolder = File(Loritta.FOLDER, "plugins/$name")
 

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
@@ -12,7 +12,7 @@ open class LorittaPlugin {
 	lateinit var pluginFile: File
 
 	val commands = mutableListOf<LorittaCommand>()
-	val dataFolder = File(Loritta.FOLDER, "plugins/$name")
+	val dataFolder by lazy { File(Loritta.FOLDER, "plugins/$name") }
 
 	open fun onEnable() {
 

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
@@ -6,7 +6,7 @@ import net.perfectdreams.commands.loritta.LorittaCommand
 import java.io.File
 import java.net.URLClassLoader
 
-open class LorittaPlugin(val name: String, val classLoader: URLClassLoader? = null) {
+open class LorittaPlugin(val name: String, val classLoader: URLClassLoader, val pluginFile: File) {
 	val commands = mutableListOf<LorittaCommand>()
 	val dataFolder = File(Loritta.FOLDER, "plugins/$name")
 

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
@@ -58,7 +58,8 @@ class PluginManager {
 		val plugin = clazz.newInstance() as LorittaPlugin
 		plugin.name = info.pluginName
 		plugin.classLoader = classLoader
-		plugin.file = file
+		plugin.pluginFile = file
+
 		plugins.add(plugin)
 		plugin.onEnable()
 

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
@@ -2,6 +2,7 @@ package com.mrpowergamerbr.loritta.plugin
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.mrpowergamerbr.loritta.Loritta
 import com.mrpowergamerbr.loritta.utils.Constants
 import com.mrpowergamerbr.loritta.utils.loritta
@@ -77,7 +78,7 @@ class PluginManager {
 		stream.close()
 		jar.close()
 
-		return Constants.YAML.load<PluginDescription>(result)
+		return Constants.MAPPER.readValue(result)
 	}
 
 	class PluginDescription @JsonCreator constructor(

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
@@ -55,7 +55,10 @@ class PluginManager {
 
 		val clazz = Class.forName(info.main, true, classLoader)
 
-		val plugin = clazz.getConstructor(String::class.java, URLClassLoader::class.java, File::class.java).newInstance(info.pluginName, classLoader, file) as LorittaPlugin
+		val plugin = clazz.newInstance() as LorittaPlugin
+		plugin.name = info.pluginName
+		plugin.classLoader = classLoader
+		plugin.file = file
 		plugins.add(plugin)
 		plugin.onEnable()
 

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
@@ -61,9 +61,9 @@ class PluginManager {
 		plugin.classLoader = classLoader
 		plugin.pluginFile = file
 
-		plugins.add(plugin)
 		plugin.onEnable()
-
+		plugins.add(plugin)
+		
 		logger.info("${info.pluginName} loaded successfully!")
 	}
 

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
@@ -1,0 +1,85 @@
+package com.mrpowergamerbr.loritta.plugin
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.mrpowergamerbr.loritta.Loritta
+import com.mrpowergamerbr.loritta.utils.Constants
+import com.mrpowergamerbr.loritta.utils.loritta
+import mu.KotlinLogging
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
+import java.util.jar.JarFile
+
+class PluginManager {
+	companion object {
+		private val logger = KotlinLogging.logger {}
+	}
+
+	val plugins = mutableListOf<LorittaPlugin>()
+
+	fun getPlugin(name: String): LorittaPlugin? {
+		return plugins.firstOrNull { it.name == name }
+	}
+
+	fun clearPlugins() {
+		plugins.forEach { this.unloadPlugin(it) }
+		plugins.clear()
+	}
+
+	fun unloadPlugin(plugin: LorittaPlugin) {
+		plugin.onDisable()
+		loritta.lorittaCommandManager.unregisterCommands(*plugin.commands.toTypedArray())
+		plugin.commands.clear()
+	}
+
+	fun loadPlugins() {
+		val folder = File(Loritta.FOLDER, "plugins")
+
+		for (file in folder.listFiles().filter { it.extension == "jar" }) {
+			loadPlugin(file)
+		}
+	}
+
+	fun loadPlugin(file: File) {
+		val info = getPluginInfo(file)
+
+		logger.info("Loading ${info.pluginName}...")
+
+		val url = file.toURI().toURL()
+
+		val classLoader = URLClassLoader.newInstance(arrayOf<URL>(url))
+		val method = URLClassLoader::class.java.getDeclaredMethod("addURL", URL::class.java)
+		method.isAccessible = true
+		method.invoke(classLoader, url)
+
+		val clazz = Class.forName(info.main, true, classLoader)
+
+		val plugin = clazz.getConstructor(String::class.java, URLClassLoader::class.java).newInstance(info.pluginName, classLoader) as LorittaPlugin
+		plugins.add(plugin)
+		plugin.onEnable()
+
+		logger.info("${info.pluginName} loaded successfully!")
+	}
+
+	fun getPluginInfo(file: File): PluginDescription {
+		val jar = JarFile(file)
+		val entry = jar.getJarEntry("plugin.yml") ?: throw InvalidPluginException("Jar does not contain plugin.yml")
+
+		val stream = jar.getInputStream(entry)
+
+		val result = stream.bufferedReader().readText()
+
+		stream.close()
+		jar.close()
+
+		return Constants.YAML.load<PluginDescription>(result)
+	}
+
+	class PluginDescription @JsonCreator constructor(
+			@JsonProperty("name")
+			val pluginName: String,
+			@JsonProperty("main")
+			val main: String
+	)
+}

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
@@ -55,7 +55,7 @@ class PluginManager {
 
 		val clazz = Class.forName(info.main, true, classLoader)
 
-		val plugin = clazz.getConstructor(String::class.java, URLClassLoader::class.java).newInstance(info.pluginName, classLoader) as LorittaPlugin
+		val plugin = clazz.getConstructor(String::class.java, URLClassLoader::class.java, File::class.java).newInstance(info.pluginName, classLoader, file) as LorittaPlugin
 		plugins.add(plugin)
 		plugin.onEnable()
 

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/PluginManager.kt
@@ -32,6 +32,7 @@ class PluginManager {
 		plugin.onDisable()
 		loritta.lorittaCommandManager.unregisterCommands(*plugin.commands.toTypedArray())
 		plugin.commands.clear()
+		plugins.remove(plugin)
 	}
 
 	fun loadPlugins() {
@@ -63,7 +64,7 @@ class PluginManager {
 
 		plugin.onEnable()
 		plugins.add(plugin)
-		
+
 		logger.info("${info.pluginName} loaded successfully!")
 	}
 

--- a/src/main/java/net/perfectdreams/commands/loritta/LorittaCommandManager.kt
+++ b/src/main/java/net/perfectdreams/commands/loritta/LorittaCommandManager.kt
@@ -5,6 +5,7 @@ import com.mongodb.client.model.Updates
 import com.mrpowergamerbr.loritta.Loritta
 import com.mrpowergamerbr.loritta.LorittaLauncher
 import com.mrpowergamerbr.loritta.commands.AbstractCommand
+import com.mrpowergamerbr.loritta.commands.vanilla.magic.PluginsCommand
 import com.mrpowergamerbr.loritta.commands.vanilla.misc.MagicPingCommand
 import com.mrpowergamerbr.loritta.events.LorittaMessageEvent
 import com.mrpowergamerbr.loritta.userdata.ServerConfig
@@ -35,6 +36,7 @@ class LorittaCommandManager(val loritta: Loritta) : CommandManager<LorittaComman
 
 	init {
 		registerCommand(MagicPingCommand())
+		registerCommand(PluginsCommand())
 
 		commandListeners.addThrowableListener { context, command, throwable ->
 			if (throwable is CommandException) {


### PR DESCRIPTION
Um sistema de plugins, atualmente bem básico: Plugins podem registrar comandos.

Cada plugin precisa ter um `plugin.yml` com o `name` (nome do plugin) e `main` (classe principal do plugin)

Assim será possível recarregar plugins durante o runtime da Lori, permitindo adicionar novos comandos e funcionalidades sem precisar reiniciar ela inteira (Ou seja, teria o `Core` (que é a Loritta principal) e os `plugins`, que implementam funcionalidades adicionais nela)