### PR TITLE
Implementação inicial da Loritta API

### DIFF
--- a/src/main/java/com/mrpowergamerbr/loritta/Loritta.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/Loritta.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import mu.KotlinLogging
 import net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder
 import net.dv8tion.jda.core.utils.cache.CacheFlag
-import net.perfectdreams.commands.loritta.LorittaCommandManager
+import net.perfectdreams.loritta.api.commands.LorittaCommandManager
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import org.bson.codecs.configuration.CodecRegistries

--- a/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/magic/PluginsCommand.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/magic/PluginsCommand.kt
@@ -5,8 +5,8 @@ import com.mrpowergamerbr.loritta.commands.CommandCategory
 import com.mrpowergamerbr.loritta.utils.LoriReply
 import com.mrpowergamerbr.loritta.utils.loritta
 import net.perfectdreams.commands.annotation.Subcommand
-import net.perfectdreams.commands.loritta.LorittaCommand
-import net.perfectdreams.commands.loritta.LorittaCommandContext
+import net.perfectdreams.loritta.api.commands.LorittaCommand
+import net.perfectdreams.loritta.api.commands.LorittaCommandContext
 import java.io.File
 
 class PluginsCommand : LorittaCommand(arrayOf("plugins"), category = CommandCategory.MAGIC) {

--- a/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/MagicPingCommand.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/MagicPingCommand.kt
@@ -5,9 +5,9 @@ import com.mrpowergamerbr.loritta.utils.LoriReply
 import com.mrpowergamerbr.loritta.utils.locale.LegacyBaseLocale
 import net.dv8tion.jda.core.entities.User
 import net.perfectdreams.commands.annotation.Subcommand
-import net.perfectdreams.commands.loritta.LorittaCommand
-import net.perfectdreams.commands.loritta.LorittaCommandContext
-import net.perfectdreams.commands.loritta.notNull
+import net.perfectdreams.loritta.api.commands.LorittaCommand
+import net.perfectdreams.loritta.api.commands.LorittaCommandContext
+import net.perfectdreams.loritta.api.commands.notNull
 import java.awt.image.BufferedImage
 import kotlin.contracts.ExperimentalContracts
 

--- a/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/plugin/LorittaPlugin.kt
@@ -2,7 +2,7 @@ package com.mrpowergamerbr.loritta.plugin
 
 import com.mrpowergamerbr.loritta.Loritta
 import com.mrpowergamerbr.loritta.utils.loritta
-import net.perfectdreams.commands.loritta.LorittaCommand
+import net.perfectdreams.loritta.api.commands.LorittaCommand
 import java.io.File
 import java.net.URLClassLoader
 

--- a/src/main/java/com/mrpowergamerbr/loritta/utils/LoriReply.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/utils/LoriReply.kt
@@ -2,7 +2,7 @@ package com.mrpowergamerbr.loritta.utils
 
 import com.mrpowergamerbr.loritta.commands.CommandContext
 import net.dv8tion.jda.core.entities.User
-import net.perfectdreams.commands.loritta.LorittaCommandContext
+import net.perfectdreams.loritta.api.commands.LorittaCommandContext
 
 class LoriReply(
 		val message: String = " ",

--- a/src/main/java/com/mrpowergamerbr/loritta/utils/LorittaUser.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/utils/LorittaUser.kt
@@ -7,7 +7,7 @@ import com.mrpowergamerbr.loritta.userdata.PermissionsConfig
 import com.mrpowergamerbr.loritta.userdata.ServerConfig
 import net.dv8tion.jda.core.entities.Member
 import net.dv8tion.jda.core.entities.User
-import net.perfectdreams.commands.loritta.LorittaCommandContext
+import net.perfectdreams.loritta.api.commands.LorittaCommandContext
 
 /**
  * Um usuário que está comunicando com a Loritta

--- a/src/main/java/com/mrpowergamerbr/loritta/utils/LorittaUtilsKotlin.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/utils/LorittaUtilsKotlin.kt
@@ -23,7 +23,7 @@ import net.dv8tion.jda.core.entities.*
 import net.dv8tion.jda.core.events.message.react.GenericMessageReactionEvent
 import net.dv8tion.jda.core.exceptions.ErrorResponseException
 import net.dv8tion.jda.core.utils.MiscUtil
-import net.perfectdreams.commands.loritta.LorittaCommandContext
+import net.perfectdreams.loritta.api.commands.LorittaCommandContext
 import org.apache.commons.lang3.ArrayUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.jsoup.nodes.Element

--- a/src/main/java/com/mrpowergamerbr/loritta/utils/MessageUtils.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/utils/MessageUtils.kt
@@ -11,7 +11,7 @@ import net.dv8tion.jda.core.MessageBuilder
 import net.dv8tion.jda.core.entities.*
 import net.dv8tion.jda.core.events.message.react.MessageReactionAddEvent
 import net.dv8tion.jda.core.events.message.react.MessageReactionRemoveEvent
-import net.perfectdreams.commands.loritta.LorittaCommandContext
+import net.perfectdreams.loritta.api.commands.LorittaCommandContext
 
 object MessageUtils {
 	fun generateMessage(message: String, sources: List<Any>?, guild: Guild?, customTokens: Map<String, String> = mutableMapOf<String, String>(), safe: Boolean = true): Message? {

--- a/src/main/java/net/perfectdreams/commands/loritta/annotation/LorittaArgumentType.kt
+++ b/src/main/java/net/perfectdreams/commands/loritta/annotation/LorittaArgumentType.kt
@@ -1,5 +1,0 @@
-package net.perfectdreams.commands.loritta.annotation
-
-enum class LorittaArgumentType {
-	IMAGE
-}

--- a/src/main/java/net/perfectdreams/loritta/api/commands/CommandException.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/commands/CommandException.kt
@@ -1,3 +1,3 @@
-package net.perfectdreams.commands.loritta
+package net.perfectdreams.loritta.api.commands
 
 class CommandException(val reason: String, val prefix: String) : RuntimeException()

--- a/src/main/java/net/perfectdreams/loritta/api/commands/LorittaCommand.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/commands/LorittaCommand.kt
@@ -1,4 +1,4 @@
-package net.perfectdreams.commands.loritta
+package net.perfectdreams.loritta.api.commands
 
 import com.mrpowergamerbr.loritta.commands.CommandArguments
 import com.mrpowergamerbr.loritta.commands.CommandCategory

--- a/src/main/java/net/perfectdreams/loritta/api/commands/LorittaCommandManager.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/commands/LorittaCommandManager.kt
@@ -1,4 +1,4 @@
-package net.perfectdreams.commands.loritta
+package net.perfectdreams.loritta.api.commands
 
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Updates

--- a/src/main/java/net/perfectdreams/loritta/api/commands/annotation/InjectLoritta.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/commands/annotation/InjectLoritta.kt
@@ -1,3 +1,3 @@
-package net.perfectdreams.commands.loritta.annotation
+package net.perfectdreams.loritta.api.commands.annotation
 
 annotation class InjectLoritta(val type: LorittaArgumentType)

--- a/src/main/java/net/perfectdreams/loritta/api/commands/annotation/LorittaArgumentType.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/commands/annotation/LorittaArgumentType.kt
@@ -1,0 +1,5 @@
+package net.perfectdreams.loritta.api.commands.annotation
+
+enum class LorittaArgumentType {
+	IMAGE
+}

--- a/src/main/java/net/perfectdreams/loritta/api/entities/Message.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/entities/Message.kt
@@ -1,0 +1,6 @@
+package net.perfectdreams.loritta.api.entities
+
+interface Message {
+	val author: User
+	val content: String
+}

--- a/src/main/java/net/perfectdreams/loritta/api/entities/User.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/entities/User.kt
@@ -1,0 +1,6 @@
+package net.perfectdreams.loritta.api.entities
+
+interface User {
+	val name: String
+	val avatarUrl: String
+}

--- a/src/main/java/net/perfectdreams/loritta/api/impl/DiscordMessage.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/impl/DiscordMessage.kt
@@ -1,0 +1,10 @@
+package net.perfectdreams.loritta.api.impl
+
+import net.perfectdreams.loritta.api.entities.Message
+import net.perfectdreams.loritta.api.entities.User
+
+class DiscordMessage(val handle: net.dv8tion.jda.core.entities.Message) : Message {
+	override val author: User
+		get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+	override val content = handle.contentRaw
+}

--- a/src/main/java/net/perfectdreams/loritta/api/impl/DiscordMessage.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/impl/DiscordMessage.kt
@@ -1,10 +1,8 @@
 package net.perfectdreams.loritta.api.impl
 
 import net.perfectdreams.loritta.api.entities.Message
-import net.perfectdreams.loritta.api.entities.User
 
 class DiscordMessage(val handle: net.dv8tion.jda.core.entities.Message) : Message {
-	override val author: User
-		get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+	override val author = DiscordUser(handle.author)
 	override val content = handle.contentRaw
 }

--- a/src/main/java/net/perfectdreams/loritta/api/impl/DiscordUser.kt
+++ b/src/main/java/net/perfectdreams/loritta/api/impl/DiscordUser.kt
@@ -1,0 +1,8 @@
+package net.perfectdreams.loritta.api.impl
+
+import net.perfectdreams.loritta.api.entities.User
+
+class DiscordUser(val handle: net.dv8tion.jda.core.entities.User) : User {
+	override val name = handle.name
+	override val avatarUrl = handle.effectiveAvatarUrl
+}


### PR DESCRIPTION
Plugins devem ser feitos utilizando a Loritta API, em vez de usar a API do JDA.

Isto é uma "pseudo-continuação" da [Loritta Cinnamon](https://github.com/LorittaBot/LorittaCinnamon), permitindo que futuramente a Loritta suporte mais plataformas (em vez de somente o Discord)

Atualmente apenas duas classes existem: `Message` e `User`, mas isto já deve ser bom o suficiente para suportar o básico que a gente precisa.

Se acontecer um "oh no, precisamos implementar algo que ainda não suporta na API!!!", `(message as DiscordMessage).handle` retorna a versão original da mensagem.