### PR TITLE
Pequeno fix no +slap

### DIFF
--- a/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/actions/SlapCommand.kt
+++ b/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/actions/SlapCommand.kt
@@ -14,7 +14,7 @@ class SlapCommand : ActionCommand("slap", listOf("tapa")) {
 			locale.format(first.asMention, second.asMention) { commands.actions.slap.response }
 		} else {
 			// Quem tentar estapear a Loritta, vai ser estapeado
-			locale.format(first.asMention, second.asMention) { commands.actions.slap.responseAntiIdiot }
+			locale.format(second.asMention, first.asMention) { commands.actions.slap.responseAntiIdiot }
 		}
 	}
 


### PR DESCRIPTION
Arrumar isso (estou falando da parte de "`@Nightdavisao deu um tapa bem merecido em @Loritta`", o que era pra ser o inverso):

![kqjgnvcl5y](https://user-images.githubusercontent.com/33351880/50458099-5e3a9d00-093f-11e9-85a4-5965a2345352.png)
