### PR TITLE
Sempre verifique as feature flags ativadas na configuração, em vez de apenas verificar uma vez e reutilizar o mesmo valor várias vezes

### DIFF
--- a/loritta-core/src/main/java/net/perfectdreams/loritta/utils/FeatureFlags.kt
+++ b/loritta-core/src/main/java/net/perfectdreams/loritta/utils/FeatureFlags.kt
@@ -3,18 +3,30 @@ package net.perfectdreams.loritta.utils
 import com.mrpowergamerbr.loritta.utils.loritta
 
 object FeatureFlags {
-	val NEW_WEBSITE_PORT = isEnabled(Names.NEW_WEBSITE_PORT)
-	val MEMBER_COUNTER_UPDATE = isEnabled(Names.MEMBER_COUNTER_UPDATE)
-	val ALLOW_MORE_THAN_ONE_COUNTER_FOR_PREMIUM_USERS = isEnabled(Names.ALLOW_MORE_THAN_ONE_COUNTER_FOR_PREMIUM_USERS)
-	val BOTS_CAN_HAVE_FUN_IN_THE_RAFFLE_TOO = isEnabled(Names.BOTS_CAN_HAVE_FUN_IN_THE_RAFFLE_TOO)
-	val WRECK_THE_RAFFLE_STOP_THE_WHALES = isEnabled(Names.WRECK_THE_RAFFLE_STOP_THE_WHALES)
-	val SELECT_LOW_BETTING_USERS = isEnabled(Names.SELECT_LOW_BETTING_USERS)
-	val SELECT_USERS_WITH_LESS_MONEY = isEnabled(Names.SELECT_USERS_WITH_LESS_MONEY)
-	val ADVERTISE_SPARKLYPOWER = isEnabled(Names.ADVERTISE_SPARKLYPOWER)
-	val ADVERTISE_SPONSORS = isEnabled(Names.ADVERTISE_SPONSORS)
-	val LOG_COMMANDS = isEnabled(Names.LOG_COMMANDS)
-	val DISABLE_MUSIC_RATELIMIT = isEnabled(Names.DISABLE_MUSIC_RATELIMIT)
-	val DISABLE_TRANSLATE_RATELIMIT = isEnabled(Names.DISABLE_TRANSLATE_RATELIMIT)
+	val NEW_WEBSITE_PORT: Boolean
+			get() = isEnabled(Names.NEW_WEBSITE_PORT)
+	val MEMBER_COUNTER_UPDATE: Boolean
+			get() = isEnabled(Names.MEMBER_COUNTER_UPDATE)
+	val ALLOW_MORE_THAN_ONE_COUNTER_FOR_PREMIUM_USERS: Boolean
+			get() = isEnabled(Names.ALLOW_MORE_THAN_ONE_COUNTER_FOR_PREMIUM_USERS)
+	val BOTS_CAN_HAVE_FUN_IN_THE_RAFFLE_TOO: Boolean
+			get() = isEnabled(Names.BOTS_CAN_HAVE_FUN_IN_THE_RAFFLE_TOO)
+	val WRECK_THE_RAFFLE_STOP_THE_WHALES: Boolean
+			get() = isEnabled(Names.WRECK_THE_RAFFLE_STOP_THE_WHALES)
+	val SELECT_LOW_BETTING_USERS: Boolean
+			get() = isEnabled(Names.SELECT_LOW_BETTING_USERS)
+	val SELECT_USERS_WITH_LESS_MONEY: Boolean
+			get() = isEnabled(Names.SELECT_USERS_WITH_LESS_MONEY)
+	val ADVERTISE_SPARKLYPOWER: Boolean
+			get() = isEnabled(Names.ADVERTISE_SPARKLYPOWER)
+	val ADVERTISE_SPONSORS: Boolean
+			get() = isEnabled(Names.ADVERTISE_SPONSORS)
+	val LOG_COMMANDS: Boolean
+			get() = isEnabled(Names.LOG_COMMANDS)
+	val DISABLE_MUSIC_RATELIMIT: Boolean
+			get() = isEnabled(Names.DISABLE_MUSIC_RATELIMIT)
+	val DISABLE_TRANSLATE_RATELIMIT: Boolean
+			get() = isEnabled(Names.DISABLE_TRANSLATE_RATELIMIT)
 
 	fun isEnabled(name: String): Boolean {
 		return loritta.config.loritta.featureFlags.contains(name)


### PR DESCRIPTION
O jeito atual pega se a Feature Flag está ativada apenas uma vez e reutiliza ela para *sempre*.

Isso dá problemas caso tenha que ativar/desativar feature flags sem precisar reiniciar a Lori.

Para corrigir, o pull request altera para um `get() = FeatureFlag...`, ou seja, toda hora que for utilizado `FeatureFlag.FF_NAME`, sempre será pego utilizando `isEnabled(...)`