### PR TITLE
FastBanCommand fixes & more stuff

### DIFF
--- a/loritta-plugins/lori-guild-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/loriguildstuff/commands/FastBanCommand.kt
+++ b/loritta-plugins/lori-guild-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/loriguildstuff/commands/FastBanCommand.kt
@@ -15,7 +15,8 @@ object FastBanCommand {
             "divdm" to "Enviar conteúdo (não solicitado!) via mensagem direta, fazer spam (ou seja, mandar conteúdo indesejado para outras pessoas) é contra as regras do servidor da Loritta e dos termos de uso do Discord e, caso continuar, você poderá ser suspenso do Discord e irá perder a sua conta!",
             "nsfw" to "É proibido compartilhar conteúdo NSFW (coisas obscenas como pornografia, gore e coisas relacionadas), conteúdo sugestivo, jumpscares, conteúdo de ódio, racismo, assédio, links com conteúdo ilegal e links falsos. Será punido até se passar via mensagem direta, até mesmo se a outra pessoa pedir.",
             "toxic" to "Ser tóxico (irritar e desrespeitar) com outros membros do servidor. Aprenda a respeitar e conviver com outras pessoas!",
-            "under13" to "É proibido ter uma conta de Discord caso você tenha menos de 13 anos!"
+            "under13" to "É proibido ter uma conta de Discord caso você tenha menos de 13 anos!",
+            "owo" to "Apenas um teste uwu owo"
     )
 
     fun create(loritta: LorittaDiscord) = discordCommand(loritta, listOf("b", "fastban"), CommandCategory.ADMIN) {
@@ -25,8 +26,9 @@ object FastBanCommand {
         }
 
         executesDiscord {
+            val author = this.member!!
             val staffRole = guild.getRoleById(351473717194522647L)!!
-            if (!this.member!!.roles.contains(staffRole)) {
+            if (!author.roles.contains(staffRole)) {
                 fail("Você não pode usar o meu super comandinho de banir as pessoas com motivos bonitinhos ;w;")
             }
 
@@ -53,7 +55,7 @@ object FastBanCommand {
             BanCommand.ban(
                     settings,
                     this.guild,
-                    this.member!!.user,
+                    author.user,
                     loritta.getLegacyLocaleById("default"),
                     userToBePunished,
                     fancyReason,

--- a/loritta-plugins/lori-guild-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/loriguildstuff/commands/FastBanCommand.kt
+++ b/loritta-plugins/lori-guild-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/loriguildstuff/commands/FastBanCommand.kt
@@ -15,7 +15,7 @@ object FastBanCommand {
             "divdm" to "Enviar conteúdo (não solicitado!) via mensagem direta, fazer spam (ou seja, mandar conteúdo indesejado para outras pessoas) é contra as regras do servidor da Loritta e dos termos de uso do Discord e, caso continuar, você poderá ser suspenso do Discord e irá perder a sua conta!",
             "nsfw" to "É proibido compartilhar conteúdo NSFW (coisas obscenas como pornografia, gore e coisas relacionadas), conteúdo sugestivo, jumpscares, conteúdo de ódio, racismo, assédio, links com conteúdo ilegal e links falsos. Será punido até se passar via mensagem direta, até mesmo se a outra pessoa pedir.",
             "toxic" to "Ser tóxico (irritar e desrespeitar) com outros membros do servidor. Aprenda a respeitar e conviver com outras pessoas!",
-            "owo" to "Apenas um teste ^-^"
+            "under13" to "É proibido ter uma conta de Discord caso você tenha menos de 13 anos!"
     )
 
     fun create(loritta: LorittaDiscord) = discordCommand(loritta, listOf("b", "fastban"), CommandCategory.ADMIN) {
@@ -25,29 +25,21 @@ object FastBanCommand {
         }
 
         executesDiscord {
-            val bodyguardRole = guild.getRoleById(351473717194522647L)!!
-            val author = this.member!!
-            val userToBePunished = this.user(0)?.handle
-            val reason = this.args.getOrNull(1)?.toLowerCase()
+            val staffRole = guild.getRoleById(351473717194522647L)!!
+            if (!this.member!!.roles.contains(staffRole)) {
+                fail("Você não pode usar o meu super comandinho de banir as pessoas com motivos bonitinhos ;w;")
+            }
+
+            val userToBePunished = this.user(0)?.handle ?: fail("Usuário inválido!")
+            val reason = this.args.getOrNull(1)?.toLowerCase() ?: fail("Motivos disponíveis: `${punishmentReasons.keys.joinToString(", ")}`!")
             val proof = this.args.getOrNull(2)
+            var fancyReason = punishmentReasons.getOrDefault(reason, null) ?: fail("Motivo inválido. Motivos disponíveis: `${punishmentReasons.keys.joinToString(", ")}`!")
+
             val settings = ModerationConfigSettings(
                     sendPunishmentViaDm = true,
                     sendPunishmentToPunishLog = true
             )
 
-            if (!author.roles.contains(bodyguardRole)) {
-                fail("Você não pode usar o meu super comandinho de banir as pessoas com motivos bonitinhos ;w;")
-            }
-
-            if (userToBePunished == null) {
-                fail("Usuário inválido!")
-            }
-
-            if (reason == null) {
-                fail("Motivos disponíveis: `spam, div, divdm, nsfw, toxic`!")
-            }
-
-            var fancyReason = punishmentReasons[reason]!!
 
             reply(
                     LorittaReply(
@@ -56,14 +48,12 @@ object FastBanCommand {
                     )
             )
 
-            if (proof != null) {
-                fancyReason = "[$fancyReason]($proof)"
-            }
+            if (proof != null) fancyReason = "[$fancyReason]($proof)"
 
             BanCommand.ban(
                     settings,
                     this.guild,
-                    author.user,
+                    this.member!!.user,
                     loritta.getLegacyLocaleById("default"),
                     userToBePunished,
                     fancyReason,


### PR DESCRIPTION
This PR does the following:
- Fixes the `index out of bounds for length` error;
- Names of avaliable punishment reasons are now dynamically loaded, removing the need to manually edit messages every time you add a new punishment option;
- Simplifies code by switching from if statments to the elvis operator `?:`.