### PR TITLE
Improve all moderation commands

### DIFF
--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/CommandManager.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/CommandManager.kt
@@ -113,7 +113,7 @@ class CommandManager(loritta: Loritta) {
 		commandMap.add(AjudaCommand())
 		commandMap.add(PingCommand())
 		commandMap.add(QuoteCommand())
-		commandMap.add(SayCommand())
+		// commandMap.add(SayCommand())
 		commandMap.add(EscolherCommand())
 		commandMap.add(LanguageCommand())
 		commandMap.add(PatreonCommand())

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/CommandManager.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/CommandManager.kt
@@ -192,7 +192,7 @@ class CommandManager(loritta: Loritta) {
 
 		// =======[ ADMIN ]========
 		// commandMap.add(LimparCommand())
-		commandMap.add(RoleIdCommand())
+		// commandMap.add(RoleIdCommand())
 		commandMap.add(MuteCommand())
 		commandMap.add(UnmuteCommand())
 		commandMap.add(SlowModeCommand())
@@ -202,7 +202,7 @@ class CommandManager(loritta: Loritta) {
 		commandMap.add(WarnCommand())
 		commandMap.add(UnwarnCommand())
 		commandMap.add(WarnListCommand())
-		commandMap.add(QuickPunishmentCommand())
+		// commandMap.add(QuickPunishmentCommand())
 		// commandMap.add(LockCommand())
 		// commandMap.add(UnlockCommand())
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/CommandManager.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/CommandManager.kt
@@ -191,20 +191,20 @@ class CommandManager(loritta: Loritta) {
 		// commandMap.add(MALMangaCommand())
 
 		// =======[ ADMIN ]========
-		commandMap.add(LimparCommand())
+		// commandMap.add(LimparCommand())
 		commandMap.add(RoleIdCommand())
 		commandMap.add(MuteCommand())
 		commandMap.add(UnmuteCommand())
 		commandMap.add(SlowModeCommand())
-		commandMap.add(KickCommand())
-		commandMap.add(BanCommand())
+		// commandMap.add(KickCommand())
+		// commandMap.add(BanCommand())
 		commandMap.add(UnbanCommand())
 		commandMap.add(WarnCommand())
 		commandMap.add(UnwarnCommand())
 		commandMap.add(WarnListCommand())
 		commandMap.add(QuickPunishmentCommand())
-		commandMap.add(LockCommand())
-		commandMap.add(UnlockCommand())
+		// commandMap.add(LockCommand())
+		// commandMap.add(UnlockCommand())
 
 		// =======[ MAGIC ]========
 		commandMap.add(ReloadCommand())

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/utils/locale/LocaleUtils.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/utils/locale/LocaleUtils.kt
@@ -11,9 +11,12 @@ fun BaseLocale.getLocaleId(loritta: Loritta = LorittaLauncher.loritta) =
 fun LegacyBaseLocale.getLocaleId(loritta: Loritta = LorittaLauncher.loritta) =
         loritta.legacyLocales.entries.first { it.value == this }.key
 
-fun Profile.getBaseLocale(loritta: Loritta = LorittaLauncher.loritta, default: LegacyBaseLocale? = null): BaseLocale =
-        getLegacyBaseLocale(loritta).toNewLocale()
+fun Profile.getBaseLocale(loritta: Loritta = LorittaLauncher.loritta, default: BaseLocale? = null): BaseLocale =
+        getLegacyBaseLocale(loritta, default?.adaptToLegacy(loritta)).toNewLocale()
 
 fun Profile.getLegacyBaseLocale(loritta: Loritta = LorittaLauncher.loritta, default: LegacyBaseLocale? = null): LegacyBaseLocale = if (settings.language == null && default != null)
     default
 else loritta.getLegacyLocaleById(settings.language ?: default?.getLocaleId(loritta) ?: Constants.DEFAULT_LOCALE_ID)
+
+fun BaseLocale.adaptToLegacy(loritta: Loritta = LorittaLauncher.loritta): LegacyBaseLocale =
+        loritta.getLegacyLocaleById(getLocaleId(loritta))

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/BanCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/BanCommand.kt
@@ -1,0 +1,107 @@
+package net.perfectdreams.loritta.commands.vanilla.administration
+
+import com.mrpowergamerbr.loritta.Loritta
+import com.mrpowergamerbr.loritta.utils.MessageUtils
+import com.mrpowergamerbr.loritta.utils.getLorittaProfile
+import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
+import com.mrpowergamerbr.loritta.utils.locale.getBaseLocale
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.User
+import net.perfectdreams.loritta.api.commands.Command
+import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.commands.CommandContext
+import net.perfectdreams.loritta.platform.discord.LorittaDiscord
+import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
+import net.perfectdreams.loritta.utils.PunishmentAction
+import net.perfectdreams.loritta.utils.commands.*
+
+class BanCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("ban", "banir", "hackban", "forceban"), CommandCategory.ADMIN) {
+
+    override fun command(): Command<CommandContext> = create {
+        localizedDescription("commands.moderation.ban.description")
+
+        userRequiredPermissions = listOf(Permission.BAN_MEMBERS)
+        botRequiredPermissions = listOf(Permission.BAN_MEMBERS)
+
+
+        examples {
+            + "159985870458322944"
+            + "159985870458322944 ${it["commands.moderation.ban.randomReason"]}"
+        }
+
+        executesDiscord {
+            if (args.isEmpty()) return@executesDiscord explain()
+
+            val (users, rawReason) = checkAndRetrieveAllValidUsersFromMessages() ?: return@executesDiscord
+            val members = mapToMemberFollowingPunishmentRequirements(users)
+
+            if (members.isEmpty()) return@executesDiscord
+
+            val (reason, skipConfirmation, silent, delDays) = parsePunishmentModifiers(rawReason)
+            val settings = retrieveModerationInfo(serverConfig)
+
+            val action = createPunishmentAction { message: Message?, silent: Boolean ->
+                for (user in users) {
+                    val userLocale = user.getLorittaProfile()?.getBaseLocale(loritta as Loritta, locale) ?: guildLocale
+
+                    applyPunishment(settings, guild, user, guildLocale, userLocale, user, reason, silent, delDays)
+                }
+                message?.delete()?.queue()
+
+                sendSuccessfullyPunishedMessage(reason, delDays == 0)
+            }
+
+            if (skipConfirmation) {
+                return@executesDiscord action(null, silent)
+            }
+
+            val hasSilent = settings.sendPunishmentViaDm || settings.sendPunishmentToPunishLog
+            val message = sendConfirmationMessage(users, hasSilent, "ban")
+
+            handlePunishmentConfirmation(message, action)
+        }
+    }
+
+    private fun applyPunishment(settings: ModerationConfigSettings, guild: Guild, punisher: User, serverLocale: BaseLocale, userProfile: BaseLocale, user: User, reason: String, isSilent: Boolean, delDays: Int) {
+        if (!isSilent) {
+            handleNonSilentPunishmentStuff(settings, guild, punisher, serverLocale, userProfile, user, reason)
+        }
+
+        guild.ban(user, delDays, generateAuditLogMessage(serverLocale, punisher, reason)).queue()
+    }
+
+    private fun handleNonSilentPunishmentStuff(settings: ModerationConfigSettings, guild: Guild, punisher: User, serverLocale: BaseLocale, userProfile: BaseLocale, user: User, reason: String) {
+        if (settings.sendPunishmentViaDm && guild.isMember(user)) {
+            runCatching {
+                val embed = createPunishmentMessageSentViaDirectMessage(guild, userProfile, punisher, userProfile["commands.moderation.ban.punishAction"], reason)
+
+                user.openPrivateChannel().queue {
+                    it.sendMessage(embed).queue()
+                }
+            }.onFailure { it.printStackTrace() }
+        }
+
+        val punishLogMessage = getPunishmentForMessage(settings, guild, PunishmentAction.BAN)
+
+        if (settings.sendPunishmentToPunishLog && settings.punishLogChannelId != null && punishLogMessage != null) {
+            val textChannel = guild.getTextChannelById(settings.punishLogChannelId)
+
+            if (textChannel != null && textChannel.canTalk()) {
+                val message = MessageUtils.generateMessage(
+                        punishLogMessage,
+                        listOf(user, guild),
+                        guild,
+                        mutableMapOf(
+                                "duration" to serverLocale["commands.moderation.mute.forever"]
+                        ) + getStaffCustomTokens(punisher) + getPunishmentCustomTokens(serverLocale, reason, "commands.moderation.ban")
+                )
+
+                message?.let {
+                    textChannel.sendMessage(it).queue()
+                }
+            }
+        }
+    }
+}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
@@ -1,0 +1,77 @@
+package net.perfectdreams.loritta.commands.vanilla.administration
+
+import com.mrpowergamerbr.loritta.utils.Constants
+import com.mrpowergamerbr.loritta.utils.extensions.await
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageChannel
+import net.dv8tion.jda.api.entities.TextChannel
+import net.perfectdreams.loritta.api.commands.ArgumentType
+import net.perfectdreams.loritta.api.commands.Command
+import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.commands.CommandContext
+import net.perfectdreams.loritta.api.messages.LorittaReply
+import net.perfectdreams.loritta.platform.discord.LorittaDiscord
+import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
+
+class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("clean", "limpar", "clear"), CommandCategory.ADMIN) {
+
+    override fun command(): Command<CommandContext> = create {
+        localizedDescription("commands.moderation.clear.description")
+        localizedExamples("commands.moderation.clear.examples")
+
+        userRequiredPermissions = listOf(Permission.MESSAGE_MANAGE)
+        botRequiredPermissions = listOf(Permission.MESSAGE_MANAGE, Permission.MESSAGE_HISTORY)
+
+        usage {
+            argument(ArgumentType.NUMBER) {
+                optional = false
+            }
+            argument(ArgumentType.USER){
+                optional = true
+            }
+        }
+
+        // TODO: Improve
+        executesDiscord {
+            if (args.isEmpty()) return@executesDiscord explain()
+
+            val count = args[0].toIntOrNull()
+            val channel = discordMessage.channel as? TextChannel ?: return@executesDiscord
+
+            if (count == null || count !in 2..100)
+                fail(locale["commands.moderation.clear.invalidClearRange"], Constants.ERROR)
+
+            message.runCatching {
+                delete()
+            }
+
+            val messages = channel.history.retrievePast(count).await()
+
+            val disallowedMessages = messages.filter { (((System.currentTimeMillis() / 1000) - it.timeCreated.toEpochSecond()) > 1209600) || (it.isPinned) }
+            val allowedMessages = messages - disallowedMessages
+
+            if (allowedMessages.isEmpty())
+                fail(locale["commands.moderation.clear.couldNotFindMessages"], Constants.ERROR)
+            else clear(channel, messages)
+
+            val replies = mutableListOf(LorittaReply(locale["commands.moderation.clear.success", user.asMention], "\uD83E\uDD73"))
+
+            if (disallowedMessages.isNotEmpty())
+                replies.add(LorittaReply(
+                        locale["commands.moderation.clear.ignoredMessages", disallowedMessages.size],
+                        "\uD83D\uDD37",
+                        mentionUser = false
+                ))
+
+            reply(replies)
+        }
+    }
+
+    suspend fun clear(channel: TextChannel, messages: List<Message>) {
+        val allowedMessages = messages - messages.filter { (((System.currentTimeMillis() / 1000) - it.timeCreated.toEpochSecond() > 14 * 24 * 60 * 60) || (it.isPinned)) && it.channel.idLong == channel.idLong }
+
+        channel.deleteMessages(allowedMessages).await()
+    }
+
+}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
@@ -4,7 +4,6 @@ import com.mrpowergamerbr.loritta.utils.Constants
 import com.mrpowergamerbr.loritta.utils.extensions.await
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.entities.MessageChannel
 import net.dv8tion.jda.api.entities.TextChannel
 import net.perfectdreams.loritta.api.commands.ArgumentType
 import net.perfectdreams.loritta.api.commands.Command

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
@@ -32,12 +32,13 @@ class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta,
             }
         }
 
-        // TODO: Improve
         executesDiscord {
             if (args.isEmpty()) return@executesDiscord explain()
 
             val count = args[0].toIntOrNull()
             val channel = discordMessage.channel as? TextChannel ?: return@executesDiscord
+
+            val target = user(1)
 
             if (count == null || count !in 2..100)
                 fail(locale["commands.moderation.clear.invalidClearRange"], Constants.ERROR)
@@ -48,7 +49,7 @@ class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta,
 
             val messages = channel.history.retrievePast(count).await()
 
-            val disallowedMessages = messages.filter { (((System.currentTimeMillis() / 1000) - it.timeCreated.toEpochSecond()) > 1209600) || (it.isPinned) }
+            val disallowedMessages = messages.filter { ((((System.currentTimeMillis() / 1000) - it.timeCreated.toEpochSecond()) > 1209600) || (it.isPinned)) && if (target != null) it.author.idLong == target.id else true }
             val allowedMessages = messages - disallowedMessages
 
             if (allowedMessages.isEmpty())

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/KickCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/KickCommand.kt
@@ -1,25 +1,26 @@
 package net.perfectdreams.loritta.commands.vanilla.administration
 
+import com.mrpowergamerbr.loritta.Loritta
+import com.mrpowergamerbr.loritta.commands.vanilla.administration.AdminUtils
+import com.mrpowergamerbr.loritta.utils.getLorittaProfile
 import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
+import com.mrpowergamerbr.loritta.utils.locale.getBaseLocale
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.User
-import net.perfectdreams.loritta.api.commands.ArgumentType
-import net.perfectdreams.loritta.api.commands.Command
-import net.perfectdreams.loritta.api.commands.CommandCategory
-import net.perfectdreams.loritta.api.commands.CommandContext
+import net.perfectdreams.loritta.api.commands.*
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 import net.perfectdreams.loritta.utils.PunishmentAction
 import net.perfectdreams.loritta.utils.commands.*
 
-class BanCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("ban", "banir", "hackban", "forceban"), CommandCategory.ADMIN) {
+class KickCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("kick", "expulsar", "kickar"), CommandCategory.ADMIN) {
 
     override fun command(): Command<CommandContext> = create {
-        localizedDescription("commands.moderation.ban.description")
+        localizedDescription("commands.moderation.kick.description")
 
-        userRequiredPermissions = listOf(Permission.BAN_MEMBERS)
-        botRequiredPermissions = listOf(Permission.BAN_MEMBERS)
+        userRequiredPermissions = listOf(Permission.KICK_MEMBERS)
+        botRequiredPermissions = listOf(Permission.KICK_MEMBERS)
 
         examples {
             + "159985870458322944"
@@ -50,11 +51,13 @@ class BanCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, l
     companion object: PunishmentHandler {
 
         override fun applyPunishment(settings: ModerationConfigSettings, guild: Guild, punisher: User, guildLocale: BaseLocale, userLocale: BaseLocale, user: User, reason: String, isSilent: Boolean, delDays: Int) {
+            val member = guild.getMember(user) ?: return
             if (!isSilent) {
-                settings.handleNonSilentPunishment(PunishmentAction.BAN, guild, punisher, guildLocale, userLocale, user, reason)
+                settings.handleNonSilentPunishment(PunishmentAction.KICK, guild, punisher, guildLocale, userLocale, user, reason)
             }
 
-            guild.ban(user, delDays, generateAuditLogMessage(guildLocale, punisher, reason)).queue()
+            guild.kick(member, generateAuditLogMessage(guildLocale, punisher, reason)).queue()
         }
     }
+
 }

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/KickCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/KickCommand.kt
@@ -1,14 +1,13 @@
 package net.perfectdreams.loritta.commands.vanilla.administration
 
-import com.mrpowergamerbr.loritta.Loritta
-import com.mrpowergamerbr.loritta.commands.vanilla.administration.AdminUtils
-import com.mrpowergamerbr.loritta.utils.getLorittaProfile
 import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
-import com.mrpowergamerbr.loritta.utils.locale.getBaseLocale
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.User
-import net.perfectdreams.loritta.api.commands.*
+import net.perfectdreams.loritta.api.commands.ArgumentType
+import net.perfectdreams.loritta.api.commands.Command
+import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.commands.CommandContext
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 import net.perfectdreams.loritta.utils.PunishmentAction

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/LockCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/LockCommand.kt
@@ -1,0 +1,44 @@
+package net.perfectdreams.loritta.commands.vanilla.administration
+
+import net.dv8tion.jda.api.Permission
+import net.perfectdreams.loritta.api.commands.Command
+import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.commands.CommandContext
+import net.perfectdreams.loritta.platform.discord.LorittaDiscord
+import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
+import net.perfectdreams.loritta.utils.commands.*
+
+class LockCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("lock", "trancar"), CommandCategory.ADMIN) {
+
+    override fun command(): Command<CommandContext> = create {
+        localizedDescription("commands.moderation.lock.description")
+
+        userRequiredPermissions = listOf(Permission.MANAGE_SERVER)
+        botRequiredPermissions = listOf(Permission.MANAGE_CHANNEL, Permission.MANAGE_PERMISSIONS)
+
+        executesDiscord {
+            val channel = getTextChannel(args.getOrNull(0), executedIfNull = true)!!
+
+            val publicRole = guild.publicRole
+            val override = channel.getPermissionOverride(publicRole)
+
+            if (override != null) {
+                if (Permission.MESSAGE_WRITE !in override.denied) {
+                    override.manager
+                            .deny(Permission.MESSAGE_WRITE)
+                            .queue()
+                }
+            } else {
+                channel.createPermissionOverride(publicRole)
+                        .setDeny(Permission.MESSAGE_WRITE)
+                        .queue()
+            }
+
+            reply(
+                    locale["commands.moderation.lock.denied", serverConfig.commandPrefix],
+                    "\uD83C\uDF89"
+            )
+        }
+    }
+
+}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/LockCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/LockCommand.kt
@@ -6,7 +6,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.CommandContext
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
-import net.perfectdreams.loritta.utils.commands.*
+import net.perfectdreams.loritta.utils.commands.getTextChannel
 
 class LockCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("lock", "trancar"), CommandCategory.ADMIN) {
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/QuickPunishmentCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/QuickPunishmentCommand.kt
@@ -1,0 +1,32 @@
+package net.perfectdreams.loritta.commands.vanilla.administration
+
+import net.perfectdreams.loritta.api.commands.Command
+import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.commands.CommandContext
+import net.perfectdreams.loritta.platform.discord.LorittaDiscord
+import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
+
+class QuickPunishmentCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("quickpunishment"), CommandCategory.ADMIN) {
+
+    override fun command(): Command<CommandContext> = create {
+        localizedDescription("commands.moderation.quickpunishment.description")
+
+        executesDiscord {
+            val userData = serverConfig.getUserData(user.idLong)
+
+            if (userData.quickPunishment) {
+                reply(
+                        message = locale["commands.moderation.quickpunishment.disabled"]
+                )
+            } else {
+                reply(
+                        message = locale["commands.moderation.quickpunishment.enabled"]
+                )
+            }
+
+            loritta.newSuspendedTransaction {
+                userData.quickPunishment = !userData.quickPunishment
+            }
+        }
+    }
+}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/RoleIdCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/RoleIdCommand.kt
@@ -1,0 +1,75 @@
+package net.perfectdreams.loritta.commands.vanilla.administration
+
+import com.mrpowergamerbr.loritta.commands.vanilla.administration.RoleIdCommand
+import net.perfectdreams.loritta.api.commands.ArgumentType
+import net.perfectdreams.loritta.api.commands.Command
+import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.commands.CommandContext
+import net.perfectdreams.loritta.api.messages.LorittaReply
+import net.perfectdreams.loritta.platform.discord.LorittaDiscord
+import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
+
+class RoleIdCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("roleid", "cargoid", "iddocargo"), CommandCategory.ADMIN) {
+
+    override fun command(): Command<CommandContext> = create {
+        localizedDescription("commands.moderation.roleId.description")
+        localizedExamples("commands.moderation.roleId.examples")
+
+        usage {
+            argument(ArgumentType.TEXT) {
+                optional = false
+            }
+        }
+
+        executesDiscord {
+            if (args.isEmpty()) return@executesDiscord explain()
+
+            val joinedArguments = args.joinToString(" ")
+
+            val replies = mutableListOf<LorittaReply>()
+            val mentionedRoles = discordMessage.mentionedRoles
+
+            if (mentionedRoles.isNotEmpty()) {
+                replies.add(
+                        LorittaReply(
+                                message = locale["commands.moderation.roleId.identifiers", joinedArguments],
+                                prefix = "\uD83D\uDCBC"
+                        )
+                )
+
+                mentionedRoles.mapTo(replies) {
+                    LorittaReply(
+                            message = "*${it.name}* - `${it.id}`",
+                            mentionUser = false
+                    )
+                }
+            } else {
+                val roles = guild.roles.filter { it.name.contains(joinedArguments, true) }
+
+                replies.add(LorittaReply(
+                        message = locale["${RoleIdCommand.LOCALE_PREFIX}.roleId.rolesThatContains", joinedArguments],
+                        prefix = "\uD83D\uDCBC"
+                ))
+
+                if (roles.isEmpty()) {
+                    replies.add(
+                            LorittaReply(
+                                    message = "*${locale["${RoleIdCommand.LOCALE_PREFIX}.roleId.emptyRoles"]}*",
+                                    mentionUser = false,
+                                    prefix = "\uD83D\uDE22"
+                            )
+                    )
+                } else {
+                    roles.mapTo(replies) {
+                        LorittaReply(
+                                message = "*${it.name}* - `${it.id}`",
+                                mentionUser = false
+                        )
+                    }
+                }
+            }
+            reply(replies)
+        }
+    }
+
+}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/SayCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/SayCommand.kt
@@ -1,7 +1,10 @@
 package net.perfectdreams.loritta.commands.vanilla.administration
 
 import com.mrpowergamerbr.loritta.commands.vanilla.administration.SayCommand
-import com.mrpowergamerbr.loritta.utils.*
+import com.mrpowergamerbr.loritta.utils.Constants
+import com.mrpowergamerbr.loritta.utils.LorittaPermission
+import com.mrpowergamerbr.loritta.utils.MessageUtils
+import com.mrpowergamerbr.loritta.utils.escapeMentions
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.MessageChannel
 import net.dv8tion.jda.api.entities.TextChannel
@@ -9,7 +12,6 @@ import net.perfectdreams.loritta.api.commands.ArgumentType
 import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.CommandContext
-import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 import net.perfectdreams.loritta.utils.commands.getTextChannel

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/SayCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/SayCommand.kt
@@ -1,0 +1,88 @@
+package net.perfectdreams.loritta.commands.vanilla.administration
+
+import com.mrpowergamerbr.loritta.commands.vanilla.administration.SayCommand
+import com.mrpowergamerbr.loritta.utils.*
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.MessageChannel
+import net.dv8tion.jda.api.entities.TextChannel
+import net.perfectdreams.loritta.api.commands.ArgumentType
+import net.perfectdreams.loritta.api.commands.Command
+import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.commands.CommandContext
+import net.perfectdreams.loritta.api.messages.LorittaReply
+import net.perfectdreams.loritta.platform.discord.LorittaDiscord
+import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
+import net.perfectdreams.loritta.utils.commands.getTextChannel
+
+class SayCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("say", "falar"), CommandCategory.ADMIN) {
+
+    override fun command(): Command<CommandContext> = create {
+        localizedDescription("commands.moderation.say.description")
+        localizedExamples("commands.moderation.say.examples")
+
+        usage {
+            argument(ArgumentType.TEXT) {
+                optional = false
+            }
+        }
+
+        executesDiscord {
+            if (args.isEmpty()) return@executesDiscord explain()
+
+            var args = args
+            var channel: MessageChannel? = getTextChannel(args[0])
+
+            if (channel != null)
+                args = args.drop(1)
+            else {
+                channel = discordMessage.channel
+            }
+
+            if (channel is TextChannel) { // Caso seja text channel...
+                if (!channel.canTalk()) {
+                    fail(
+                            locale["${SayCommand.LOCALE_PREFIX}.say.iDontHavePermissionToTalkIn", channel.asMention],
+                            Constants.ERROR
+                    )
+                }
+                if (!channel.canTalk(member!!)) {
+                    fail(
+                            locale["${SayCommand.LOCALE_PREFIX}.say.youDontHavePermissionToTalkIn", channel.asMention],
+                            Constants.ERROR
+                    )
+                }
+                if (serverConfig.blacklistedChannels.contains(channel.idLong) && !lorittaUser.hasPermission(LorittaPermission.BYPASS_COMMAND_BLACKLIST)) {
+                    fail(
+                            locale["${SayCommand.LOCALE_PREFIX}.say.commandsCannotBeUsedIn", channel.asMention],
+                            Constants.ERROR
+                    )
+                }
+            }
+
+            var text = args.joinToString(" ")
+
+            if (!isPrivateChannel && member?.hasPermission(channel as TextChannel, Permission.MESSAGE_MENTION_EVERYONE) == true)
+                text = text.escapeMentions()
+
+            // Watermarks the message to "deanonymise" the message, to avoid users reporting Loritta for ToS breaking stuff, even tho it was
+            // a malicious user sending the messages.
+            val watermarkedMessage = MessageUtils.watermarkMessage(
+                    text,
+                    user,
+                    locale["${SayCommand.LOCALE_PREFIX}.say.messageSentBy"]
+            )
+
+            val preparedMessage = runCatching {
+                MessageUtils.generateMessage(
+                        watermarkedMessage,
+                        listOf(guild, user),
+                        guild
+                )
+            }.getOrNull() ?: run {
+                return@executesDiscord channel.sendMessage(text).queue()
+            }
+
+            channel.sendMessage(preparedMessage).queue()
+        }
+    }
+}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/UnlockCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/UnlockCommand.kt
@@ -1,0 +1,44 @@
+package net.perfectdreams.loritta.commands.vanilla.administration
+
+import net.dv8tion.jda.api.Permission
+import net.perfectdreams.loritta.api.commands.Command
+import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.commands.CommandContext
+import net.perfectdreams.loritta.platform.discord.LorittaDiscord
+import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
+import net.perfectdreams.loritta.utils.commands.getTextChannel
+
+class UnlockCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("unlock", "destrancar"), CommandCategory.ADMIN) {
+
+    override fun command(): Command<CommandContext> = create {
+        localizedDescription("commands.moderation.unlock.description")
+
+        userRequiredPermissions = listOf(Permission.MANAGE_SERVER)
+        botRequiredPermissions = listOf(Permission.MANAGE_CHANNEL, Permission.MANAGE_PERMISSIONS)
+
+        executesDiscord {
+            val channel = getTextChannel(args.getOrNull(0), executedIfNull = true)!! // Já que o comando não será executado via DM, podemos assumir que textChannel nunca será nulo
+
+            val publicRole = guild.publicRole
+            val override = channel.getPermissionOverride(publicRole)
+
+            if (override != null) {
+                if (Permission.MESSAGE_WRITE in override.denied) {
+                    override.manager
+                            .grant(Permission.MESSAGE_WRITE)
+                            .queue()
+                }
+            } else { // Bem, na verdade não seria totalmente necessário este else, mas vamos supor que o cara usou o "+unlock" com o chat destravado sem ter travado antes :rolling_eyes:
+                channel.createPermissionOverride(publicRole)
+                        .setAllow(Permission.MESSAGE_WRITE)
+                        .queue()
+            }
+
+            reply(
+                    locale["commands.moderation.unlock.allowed", serverConfig.commandPrefix],
+                    "\uD83C\uDF89"
+            )
+        }
+    }
+
+}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
@@ -107,6 +107,7 @@ abstract class LorittaDiscord(var discordConfig: GeneralDiscordConfig, var disco
                 ClearCommand(this@LorittaDiscord),
                 KickCommand(this@LorittaDiscord),
                 LockCommand(this@LorittaDiscord),
+                SayCommand(this@LorittaDiscord),
                 UnlockCommand(this@LorittaDiscord)
         )
     }

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.*
 import mu.KotlinLogging
 import net.perfectdreams.loritta.api.LorittaBot
 import net.perfectdreams.loritta.api.utils.format
-import net.perfectdreams.loritta.commands.vanilla.administration.BanInfoCommand
+import net.perfectdreams.loritta.commands.vanilla.administration.*
 import net.perfectdreams.loritta.commands.vanilla.economy.SonhosTopCommand
 import net.perfectdreams.loritta.commands.vanilla.economy.SonhosTopLocalCommand
 import net.perfectdreams.loritta.commands.vanilla.economy.TransactionsCommand
@@ -102,7 +102,12 @@ abstract class LorittaDiscord(var discordConfig: GeneralDiscordConfig, var disco
                 XpNotificationsCommand(this@LorittaDiscord),
 
                 // ===[ ADMIN ]===
-                BanInfoCommand(this@LorittaDiscord)
+                BanCommand(this@LorittaDiscord),
+                BanInfoCommand(this@LorittaDiscord),
+                ClearCommand(this@LorittaDiscord),
+                KickCommand(this@LorittaDiscord),
+                LockCommand(this@LorittaDiscord),
+                UnlockCommand(this@LorittaDiscord)
         )
     }
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
@@ -87,6 +87,17 @@ abstract class LorittaDiscord(var discordConfig: GeneralDiscordConfig, var disco
 
     override val commandMap = DiscordCommandMap(this).apply {
         registerAll(
+                // ===[ ADMIN ]===
+                BanCommand(this@LorittaDiscord),
+                BanInfoCommand(this@LorittaDiscord),
+                ClearCommand(this@LorittaDiscord),
+                KickCommand(this@LorittaDiscord),
+                LockCommand(this@LorittaDiscord),
+                QuickPunishmentCommand(this@LorittaDiscord),
+                RoleIdCommand(this@LorittaDiscord),
+                SayCommand(this@LorittaDiscord),
+                UnlockCommand(this@LorittaDiscord),
+
                 // ===[ MAGIC ]===
                 LoriToolsCommand(this@LorittaDiscord),
 
@@ -100,15 +111,6 @@ abstract class LorittaDiscord(var discordConfig: GeneralDiscordConfig, var disco
                 RankGlobalCommand(this@LorittaDiscord),
                 RepTopCommand(this@LorittaDiscord),
                 XpNotificationsCommand(this@LorittaDiscord),
-
-                // ===[ ADMIN ]===
-                BanCommand(this@LorittaDiscord),
-                BanInfoCommand(this@LorittaDiscord),
-                ClearCommand(this@LorittaDiscord),
-                KickCommand(this@LorittaDiscord),
-                LockCommand(this@LorittaDiscord),
-                SayCommand(this@LorittaDiscord),
-                UnlockCommand(this@LorittaDiscord)
         )
     }
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/commands/DiscordCommandContext.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/commands/DiscordCommandContext.kt
@@ -9,6 +9,7 @@ import com.mrpowergamerbr.loritta.utils.LorittaUtils
 import com.mrpowergamerbr.loritta.utils.extensions.await
 import com.mrpowergamerbr.loritta.utils.extensions.localized
 import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
+import com.mrpowergamerbr.loritta.utils.locale.LegacyBaseLocale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.dv8tion.jda.api.EmbedBuilder
@@ -46,6 +47,12 @@ class DiscordCommandContext(
 		get() = discordMessage.guild
 	val user = discordMessage.author
 	val member = discordMessage.member
+
+	val guildLocale: BaseLocale
+		get() = loritta.getLocaleById(serverConfig.localeId)
+
+	val guildLegacyLocale: LegacyBaseLocale
+		get() = loritta.getLegacyLocaleById(serverConfig.localeId)
 
 	suspend fun sendMessage(message: String, embed: MessageEmbed): Message {
 		return sendMessage(MessageBuilder().setEmbed(embed).append(if (message.isEmpty()) " " else message).build())

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/commands/DiscordUtils.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/commands/DiscordUtils.kt
@@ -1,0 +1,27 @@
+package net.perfectdreams.loritta.utils.commands
+
+import com.mrpowergamerbr.loritta.utils.isValidSnowflake
+import net.dv8tion.jda.api.entities.TextChannel
+import net.perfectdreams.loritta.platform.discord.commands.DiscordCommandContext
+
+fun DiscordCommandContext.getTextChannel(input: String?, executedIfNull: Boolean = false): TextChannel? {
+    if (input == null)
+        return discordMessage.textChannel
+
+    val channels = guild.getTextChannelsByName(input, false)
+    if (channels.isNotEmpty()) {
+        return channels[0]
+    }
+
+    val id = input
+            .replace("<", "")
+            .replace("#", "")
+            .replace(">", "")
+
+    if (!id.isValidSnowflake())
+        return null
+
+    val channel = guild.getTextChannelById(id)
+
+    return if (channel == null && discordMessage.channel is TextChannel) discordMessage.textChannel else if (executedIfNull) channel else null
+}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/commands/DiscordUtils.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/commands/DiscordUtils.kt
@@ -4,7 +4,7 @@ import com.mrpowergamerbr.loritta.utils.isValidSnowflake
 import net.dv8tion.jda.api.entities.TextChannel
 import net.perfectdreams.loritta.platform.discord.commands.DiscordCommandContext
 
-fun DiscordCommandContext.getTextChannel(input: String?, executedIfNull: Boolean = false): TextChannel? {
+fun DiscordCommandContext.getTextChannel(input: String?, executedIfNull: Boolean = false): TextChannel? = runCatching {
     if (input == null)
         return discordMessage.textChannel
 
@@ -23,5 +23,5 @@ fun DiscordCommandContext.getTextChannel(input: String?, executedIfNull: Boolean
 
     val channel = guild.getTextChannelById(id)
 
-    return if (channel == null && discordMessage.channel is TextChannel) discordMessage.textChannel else if (executedIfNull) channel else null
-}
+    return@runCatching if (channel == null && discordMessage.channel is TextChannel && executedIfNull) discordMessage.textChannel else channel
+}.getOrNull()

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/commands/ModerationUtils.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/commands/ModerationUtils.kt
@@ -194,10 +194,10 @@ fun DiscordCommandContext.checkForPunishmentPermissions(target: Member) {
         fail(reply, Constants.ERROR)
     } else if (member.canInteract(target).not()) {
         val reply = buildString {
-            append(locale["$LOCALE_PREFIX.staffRoleTooLow"])
+            append(locale["$LOCALE_PREFIX.punisherRoleTooLow"])
 
             if (member.hasPermission(Permission.MANAGE_ROLES))
-                append(" ${locale["$LOCALE_PREFIX.staffRoleTooLowHowToFix"]}")
+                append(" ${locale["$LOCALE_PREFIX.punisherRoleTooLow"]}")
         }
 
         fail(reply, Constants.ERROR)


### PR DESCRIPTION
This will migrate all moderation commands to the new API & refactor them
* Loritta: https://github.com/LorittaBot/Loritta/pull/2246
* Locales: https://github.com/LorittaBot/LorittaLocales/pull/105

Roadmap (commands that were made & tested):
- [x] BanCommand.kt
- [x] ClearCommand.kt
- [x] KickCommand.kt
- [x] LockCommand.kt
- [ ] MuteCommand.kt
- [ ] QuickPunishmentCommand.kt
- [x] RoleIdCommand.kt
- [x] SayCommand.kt
- [ ] SayEditCommand.kt
- [ ] SlowModeCommand.kt
- [ ] UnbanCommand.kt
- [x] UnlockCommand.kt
- [ ] UnmuteCommand.kt
- [ ] UnwarnCommand.kt
- [ ] WarnCommand.kt
- [ ] WarnListCommand.kt