### PR TITLE
Fix Fortnite-related commands

### DIFF
--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/FortniteStuff.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/FortniteStuff.kt
@@ -1,9 +1,20 @@
 package net.perfectdreams.loritta.plugin.fortnite
 
+import com.github.salomonbrys.kotson.get
+import com.github.salomonbrys.kotson.nullString
+import com.github.salomonbrys.kotson.obj
+import com.github.salomonbrys.kotson.string
 import com.google.gson.JsonArray
+import com.google.gson.JsonElement
 import com.mrpowergamerbr.loritta.network.Databases
 import com.mrpowergamerbr.loritta.tables.ServerConfigs
+import com.mrpowergamerbr.loritta.utils.Constants
+import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
+import com.mrpowergamerbr.loritta.utils.onReactionAddByAuthor
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Message
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
+import net.perfectdreams.loritta.platform.discord.commands.DiscordCommandContext
 import net.perfectdreams.loritta.platform.discord.plugin.LorittaDiscordPlugin
 import net.perfectdreams.loritta.plugin.fortnite.commands.fortnite.*
 import net.perfectdreams.loritta.plugin.fortnite.routes.ConfigureFortniteRoute
@@ -13,6 +24,7 @@ import net.perfectdreams.loritta.plugin.fortnite.tables.FakeTable
 import net.perfectdreams.loritta.plugin.fortnite.tables.FortniteConfigs
 import net.perfectdreams.loritta.plugin.fortnite.tables.TrackedFortniteItems
 import net.perfectdreams.loritta.plugin.fortnite.transformers.FortniteConfigTransformer
+import net.perfectdreams.loritta.utils.Emotes
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.awt.Color
@@ -30,6 +42,76 @@ class FortniteStuff(name: String, loritta: LorittaDiscord) : LorittaDiscordPlugi
                 "dc" -> Color(43, 61, 88)
                 "dark" -> Color(159, 0, 120)
                 else -> Color(176, 176, 150)
+            }
+        }
+
+        /**
+         * Gets a Fortnite Item by Name or ID
+         *
+         * @param m instance of the [FortniteStuff] class
+         * @param locale the locale that the items should be in
+         * @param context command context
+         * @param name the name or ID of the item
+         * @param onSuccess when a item is found, this callback will be invoked with the Fortnite Item Element and a maybe null message (used when there is multiple items)
+         * @param onFailure when no item matched the [name]
+         */
+        suspend fun getFortniteItemByName(
+                m: FortniteStuff,
+                locale: BaseLocale,
+                context: DiscordCommandContext,
+                name: String,
+                onSuccess: suspend (JsonElement, Message?) -> (Unit),
+                onFailure: suspend () -> (Unit)
+        ) {
+            val items = m.itemsInfo.values.flatMap {
+                it.filter {
+                    it["id"].string == name || it["name"].nullString?.contains(name, true) == true
+                }
+            }.distinctBy { it["id"].string }
+
+            val fortniteItemsInCurrentLocale = m.itemsInfo[locale["commands.fortnite.shop.localeId"]]!!
+
+            val embed = EmbedBuilder()
+
+            when {
+                items.size == 1 -> {
+                    // Pegar na linguagem do usuário
+                    onSuccess.invoke(
+                            fortniteItemsInCurrentLocale.first { it["id"].string == items.first()["id"].string },
+                            null
+                    )
+                }
+                items.isNotEmpty() -> {
+                    for (i in 0 until Math.min(9, items.size)) {
+                        val item = items[i].obj
+                        val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["id"].string == it["id"].string }.obj
+
+                        embed.setTitle("${Emotes.LORI_HM} ${locale["commands.fortnite.item.multipleItems"]}")
+                        embed.setColor(Color(0, 125, 187))
+                        embed.appendDescription("${Constants.INDEXES[i]} ${fortniteItemInCurrentLocale["name"].nullString} (${fortniteItemInCurrentLocale["type"]["value"].nullString})\n")
+                    }
+
+                    val result = context.sendMessage(embed.build())
+
+                    result.onReactionAddByAuthor(context) {
+                        val idx = Constants.INDEXES.indexOf(it.reactionEmote.name)
+
+                        // Caso seja uma reaçõa inválida ou que não tem no metadata, ignore!
+                        if (idx == -1 || (idx + 1) > items.size)
+                            return@onReactionAddByAuthor
+
+                        val item = items[idx]
+                        val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["id"].string == it["id"].string }
+
+                        onSuccess.invoke(fortniteItemInCurrentLocale, result)
+                    }
+
+                    // Adicionar os reactions
+                    for (i in 0 until Math.min(9, items.size)) {
+                        result.addReaction(Constants.INDEXES[i]).queue()
+                    }
+                }
+                else -> onFailure.invoke()
             }
         }
 

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/UpdateStoreItemsTask.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/UpdateStoreItemsTask.kt
@@ -66,9 +66,6 @@ class UpdateStoreItemsTask(val m: FortniteStuff) {
 									header("Authorization", com.mrpowergamerbr.loritta.utils.loritta.config.fortniteApi.token)
 								}
 
-								println(apiId)
-								println(result.substring(0, 50))
-
 								val clusters = loritta.config.clusters
 
 								clusters.map {

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/UpdateStoreItemsTask.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/UpdateStoreItemsTask.kt
@@ -4,18 +4,14 @@ import com.github.kevinsawicki.http.HttpRequest
 import com.github.salomonbrys.kotson.*
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.mrpowergamerbr.loritta.commands.vanilla.misc.PingCommand
 import com.mrpowergamerbr.loritta.network.Databases
 import com.mrpowergamerbr.loritta.tables.Profiles
 import com.mrpowergamerbr.loritta.utils.*
 import com.mrpowergamerbr.loritta.utils.extensions.await
 import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
-import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.readText
-import io.ktor.http.userAgent
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import kotlinx.coroutines.*
 import mu.KotlinLogging
 import net.dv8tion.jda.api.EmbedBuilder
@@ -33,6 +29,7 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.util.concurrent.ConcurrentHashMap
 import javax.imageio.ImageIO
+import kotlin.collections.set
 
 class UpdateStoreItemsTask(val m: FortniteStuff) {
 	companion object {
@@ -54,6 +51,8 @@ class UpdateStoreItemsTask(val m: FortniteStuff) {
 			while (true) {
 				try {
 					if (loritta.isMaster) {
+						delay(5_000)
+
 						if (System.currentTimeMillis() - lastItemListPostUpdate >= 900_000) {
 							lastItemListPostUpdate = System.currentTimeMillis()
 							logger.info { "Updating Fortnite Items..." }
@@ -62,10 +61,13 @@ class UpdateStoreItemsTask(val m: FortniteStuff) {
 							}.distinct()
 
 							for (apiId in distinctApiIds) {
-								val result = loritta.http.get<String>("https://fnapi.me/api/items/all?lang=$apiId") {
+								val result = loritta.http.get<String>("https://fortnite-api.com/v2/cosmetics/br?language=$apiId") {
 									userAgent(loritta.lorittaCluster.getUserAgent())
 									header("Authorization", com.mrpowergamerbr.loritta.utils.loritta.config.fortniteApi.token)
 								}
+
+								println(apiId)
+								println(result.substring(0, 50))
 
 								val clusters = loritta.config.clusters
 

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteItemCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteItemCommand.kt
@@ -5,7 +5,6 @@ import com.google.gson.JsonElement
 import com.mrpowergamerbr.loritta.utils.Constants
 import com.mrpowergamerbr.loritta.utils.extensions.edit
 import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
-import com.mrpowergamerbr.loritta.utils.onReactionAddByAuthor
 import com.mrpowergamerbr.loritta.utils.stripCodeMarks
 import net.dv8tion.jda.api.EmbedBuilder
 import net.perfectdreams.loritta.api.commands.ArgumentType
@@ -14,7 +13,6 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 import net.perfectdreams.loritta.plugin.fortnite.FortniteStuff
 import net.perfectdreams.loritta.utils.Emotes
-import java.awt.Color
 
 class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.loritta, listOf("fortniteitem", "fnitem"), CommandCategory.FORTNITE) {
 	private val LOCALE_PREFIX = "commands.fortnite.item"
@@ -33,7 +31,7 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 			+ "Savor the W"
 			+ "Jaywalking"
 			+ "Kitsune"
-			+ "13dfe12e98005d104710b724cafd26d42432ce81"
+			+ "CID_693_Athena_Commando_M_BuffCat"
 		}
 
 		executesDiscord {
@@ -42,72 +40,36 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 
 			val name = args.joinToString(" ")
 
-			val items = m.itemsInfo.values.flatMap {
-				it.filter {
-					it["id"].string == name || it["name"].nullString?.contains(name, true) == true
-				}
-			}.distinctBy { it["id"].string }
-
-			println("ITEMS INFO")
-			m.itemsInfo.forEach {
-				println(it.key)
-			}
-
-			val fortniteItemsInCurrentLocale = m.itemsInfo[locale["commands.fortnite.shop.localeId"]]!!
-
-			val embed = EmbedBuilder()
-
-			if (items.size == 1) {
-				// Pegar na linguagem do usuário
-				val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { it["id"].string == items.first()["id"].string }
-
-				sendMessage(
-						displayItemInfo(fortniteItemInCurrentLocale, locale).build()
-				)
-			} else if (items.isNotEmpty()) {
-				for (i in 0 until Math.min(9, items.size)) {
-					val item = items[i].obj
-					val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["id"].string == it["id"].string }.obj
-
-					embed.setTitle("${Emotes.LORI_HM} ${locale["$LOCALE_PREFIX.multipleItems"]}")
-					embed.setColor(Color(0, 125, 187))
-					embed.appendDescription("${Constants.INDEXES[i]} ${fortniteItemInCurrentLocale["name"].nullString} (${fortniteItemInCurrentLocale["type"]["value"].nullString})\n")
-				}
-
-				val result = sendMessage(embed.build())
-
-				result.onReactionAddByAuthor(this) {
-					val idx = Constants.INDEXES.indexOf(it.reactionEmote.name)
-
-					// Caso seja uma reaçõa inválida ou que não tem no metadata, ignore!
-					if (idx == -1 || (idx + 1) > items.size)
-						return@onReactionAddByAuthor
-
-					val item = items[idx]
-					val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["id"].string == it["id"].string }
-
-					result.edit(getUserMention(true), displayItemInfo(fortniteItemInCurrentLocale, locale).build(), true)
-				}
-
-				// Adicionar os reactions
-				for (i in 0 until Math.min(9, items.size)) {
-					result.addReaction(Constants.INDEXES[i]).queue()
-				}
-			} else {
-				reply(
-						LorittaReply(
-								locale["$LOCALE_PREFIX.unknownItem", "`${name.stripCodeMarks()}`"],
-								Constants.ERROR
+			FortniteStuff.getFortniteItemByName(
+					m,
+					locale,
+					this,
+					name,
+					onSuccess = { element, message ->
+						if (message == null) {
+							sendMessage(
+									displayItemInfo(element, locale).build()
+							)
+						} else {
+							message.edit(getUserMention(true), displayItemInfo(element, locale).build(), true)
+						}
+					},
+					onFailure = {
+						reply(
+								LorittaReply(
+										locale["$LOCALE_PREFIX.unknownItem", "`${name.stripCodeMarks()}`"],
+										Constants.ERROR
+								)
 						)
-				)
-			}
+					}
+			)
 		}
 	}
 
-	fun displayItemInfo(item: JsonElement, locale: BaseLocale): EmbedBuilder {
+	private fun displayItemInfo(item: JsonElement, locale: BaseLocale): EmbedBuilder {
 		val fortniteItem = item.obj
-		val source: String? = null // fortniteItem["source"].nullString
-		val upcoming = false // fortniteItem["upcoming"].nullBool ?: true
+		val source = fortniteItem["gameplayTags"].nullArray?.firstOrNull { it.string.startsWith("Cosmetics.Source") }
+				?.string
 
 		val embed = EmbedBuilder()
 				.setTitle("${Emotes.DEFAULT_DANCE} ${fortniteItem["name"].nullString}")
@@ -118,36 +80,48 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 		embed.addField("⭐ ${locale["${LOCALE_PREFIX}.rarity"]}", fortniteItem["rarity"]["displayValue"].nullString, true)
 
 		if (source != null) {
+			val splitByDot = source.split(".")
+			// Examples:
+			// "Cosmetics.Source.StarterPack"
+			// "Cosmetics.Source.ItemShop"
+			// "Cosmetics.Source.Season4.FirstWin"
+			val arg0 = splitByDot.getOrNull(0)
+			val arg1 = splitByDot.getOrNull(1)
+			val arg2 = splitByDot.getOrNull(2)
+			val arg3 = splitByDot.getOrNull(3)
+
 			val beautifulSource = when {
-				// Passe de Batalha
-				source.startsWith("battlepass") -> {
-					val seasonTotal = source.substring((source.indexOf("battlepass (season") + "battlepass (season".length) until (source.length - 1)).toInt()
+				// Battle Pass
+				arg3 == "BattlePass" && arg2 != null -> {
+					val seasonTotal = arg2.removePrefix("Season").toInt()
 
 					val chapter = ((seasonTotal - 1) / 10) + 1
 					val season = ((seasonTotal - 1) % 10) + 1
 
 					locale["${LOCALE_PREFIX}.battlePass", chapter, season]
 				}
-				source == "starterpack" -> {
+				// Starter Pack
+				arg2 == "StarterPack" -> {
 					locale["${LOCALE_PREFIX}.starterPack"]
 				}
-				source == "shop" -> {
+				// Item Shop
+				arg2 == "ItemShop" -> {
 					locale["${LOCALE_PREFIX}.shop"]
 				}
-				source.startsWith("firstwin") -> {
-					val seasonOrAnySeason = source.substring((source.indexOf("firstwin (") + "firstwin (".length) until (source.length - 1))
-
-					if (seasonOrAnySeason == "anywin") {
+				// First Win Stuff
+				arg3 == "FirstWin" && arg2 != null -> {
+					if (arg2 == "AnySeason") {
 						locale["${LOCALE_PREFIX}.firstWinAny"]
 					} else {
-						val seasonTotal = seasonOrAnySeason.replace("season", "").toInt()
+						val seasonTotal = arg2.removePrefix("Season").toInt()
 						val chapter = ((seasonTotal - 1)  / 10) + 1
 						val season = ((seasonTotal - 1) % 10) + 1
 
 						locale["${LOCALE_PREFIX}.firstWin", chapter, season]
 					}
 				}
-				source == "promo" -> {
+				// Promotion
+				source == "Cosmetics.Source.Promo" -> {
 					locale["${LOCALE_PREFIX}.promo"]
 				}
 				else -> source
@@ -155,12 +129,6 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 
 			embed.addField("\uD83D\uDD0E ${locale["${LOCALE_PREFIX}.source"]}", beautifulSource, true) // both name and value must be set
 		}
-
-		/* if (fortniteItem["costType"].nullString == "vbucks") {
-			embed.addField("<:vbucks:635158614109192199> ${locale["${LOCALE_PREFIX}.cost"]}", fortniteItem["cost"].nullInt.toString(), true)
-		} */
-
-		embed.addField("\uD83D\uDE80 ${locale["${LOCALE_PREFIX}.alreadyReleased"]}", locale["loritta.fancyBoolean.${!upcoming}"], true)
 
 		val image = fortniteItem["images"]["icon"].nullString
 

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteItemCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteItemCommand.kt
@@ -44,9 +44,14 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 
 			val items = m.itemsInfo.values.flatMap {
 				it.filter {
-					it["itemId"].string == name || it["item"]["name"].nullString?.contains(name, true) == true
+					it["id"].string == name || it["name"].nullString?.contains(name, true) == true
 				}
-			}.distinctBy { it["itemId"].string }
+			}.distinctBy { it["id"].string }
+
+			println("ITEMS INFO")
+			m.itemsInfo.forEach {
+				println(it.key)
+			}
 
 			val fortniteItemsInCurrentLocale = m.itemsInfo[locale["commands.fortnite.shop.localeId"]]!!
 
@@ -54,7 +59,7 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 
 			if (items.size == 1) {
 				// Pegar na linguagem do usuário
-				val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { it["itemId"].string == items.first()["itemId"].string }
+				val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { it["id"].string == items.first()["id"].string }
 
 				sendMessage(
 						displayItemInfo(fortniteItemInCurrentLocale, locale).build()
@@ -62,11 +67,11 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 			} else if (items.isNotEmpty()) {
 				for (i in 0 until Math.min(9, items.size)) {
 					val item = items[i].obj
-					val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["itemId"].string == it["itemId"].string }["item"].obj
+					val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["id"].string == it["id"].string }.obj
 
 					embed.setTitle("${Emotes.LORI_HM} ${locale["$LOCALE_PREFIX.multipleItems"]}")
 					embed.setColor(Color(0, 125, 187))
-					embed.appendDescription("${Constants.INDEXES[i]} ${fortniteItemInCurrentLocale["name"].nullString} (${fortniteItemInCurrentLocale["typeName"].nullString})\n")
+					embed.appendDescription("${Constants.INDEXES[i]} ${fortniteItemInCurrentLocale["name"].nullString} (${fortniteItemInCurrentLocale["type"]["value"].nullString})\n")
 				}
 
 				val result = sendMessage(embed.build())
@@ -79,7 +84,7 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 						return@onReactionAddByAuthor
 
 					val item = items[idx]
-					val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["itemId"].string == it["itemId"].string }
+					val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["id"].string == it["id"].string }
 
 					result.edit(getUserMention(true), displayItemInfo(fortniteItemInCurrentLocale, locale).build(), true)
 				}
@@ -100,17 +105,17 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 	}
 
 	fun displayItemInfo(item: JsonElement, locale: BaseLocale): EmbedBuilder {
-		val fortniteItem = item["item"].obj
-		val source = fortniteItem["source"].nullString
-		val upcoming = fortniteItem["upcoming"].nullBool ?: true
+		val fortniteItem = item.obj
+		val source: String? = null // fortniteItem["source"].nullString
+		val upcoming = false // fortniteItem["upcoming"].nullBool ?: true
 
 		val embed = EmbedBuilder()
 				.setTitle("${Emotes.DEFAULT_DANCE} ${fortniteItem["name"].nullString}")
 				.setDescription(fortniteItem["description"].nullString)
 
-		embed.addField("\uD83D\uDD16 ${locale["${LOCALE_PREFIX}.type"]}", fortniteItem["typeName"].nullString, true)
+		embed.addField("\uD83D\uDD16 ${locale["${LOCALE_PREFIX}.type"]}", fortniteItem["type"]["displayValue"].nullString, true)
 
-		embed.addField("⭐ ${locale["${LOCALE_PREFIX}.rarity"]}", fortniteItem["rarityName"].nullString, true)
+		embed.addField("⭐ ${locale["${LOCALE_PREFIX}.rarity"]}", fortniteItem["rarity"]["displayValue"].nullString, true)
 
 		if (source != null) {
 			val beautifulSource = when {
@@ -151,20 +156,20 @@ class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 			embed.addField("\uD83D\uDD0E ${locale["${LOCALE_PREFIX}.source"]}", beautifulSource, true) // both name and value must be set
 		}
 
-		if (fortniteItem["costType"].nullString == "vbucks") {
+		/* if (fortniteItem["costType"].nullString == "vbucks") {
 			embed.addField("<:vbucks:635158614109192199> ${locale["${LOCALE_PREFIX}.cost"]}", fortniteItem["cost"].nullInt.toString(), true)
-		}
+		} */
 
 		embed.addField("\uD83D\uDE80 ${locale["${LOCALE_PREFIX}.alreadyReleased"]}", locale["loritta.fancyBoolean.${!upcoming}"], true)
 
-		val image = fortniteItem["images"]["background"].nullString
+		val image = fortniteItem["images"]["icon"].nullString
 
 		embed.setThumbnail(image)
 		embed.setColor(
-				FortniteStuff.convertRarityToColor(fortniteItem["rarity"].nullString ?: "???")
+				FortniteStuff.convertRarityToColor(fortniteItem["rarity"]["value"].nullString ?: "???")
 		)
 
-		embed.addField("\uD83D\uDCBB ID", "`${item["itemId"].string}`", true)
+		embed.addField("\uD83D\uDCBB ID", "`${item["id"].string}`", true)
 
 		return embed
 	}

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteNewsCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteNewsCommand.kt
@@ -1,9 +1,6 @@
 package net.perfectdreams.loritta.plugin.fortnite.commands.fortnite
 
-import com.github.salomonbrys.kotson.array
-import com.github.salomonbrys.kotson.nullString
-import com.github.salomonbrys.kotson.obj
-import com.github.salomonbrys.kotson.string
+import com.github.salomonbrys.kotson.*
 import com.mrpowergamerbr.loritta.Loritta
 import com.mrpowergamerbr.loritta.gifs.GifSequenceWriter
 import com.mrpowergamerbr.loritta.utils.LorittaUtils
@@ -28,7 +25,7 @@ class FortniteNewsCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 		executesDiscord {
 			val newsPayload = m.updateStoreItems!!.getNewsData("br", locale["commands.fortnite.shop.localeId"])
 
-			val data = newsPayload["data"].array
+			val data = newsPayload.obj["data"]["motds"].array
 
 			val embed = EmbedBuilder()
 					.setImage("attachment://fortnite-news.gif")
@@ -40,10 +37,10 @@ class FortniteNewsCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 
 			for (_entry in data) {
 				val entry = _entry.obj
-				val markerText = entry["adspace"].nullString
+				val markerText = entry["tabTitle"].nullString
 				val title = entry["title"].string
 				val body = entry["body"].string
-				val imageUrl = entry["image"].string
+				val imageUrl = entry["tileImage"].string
 
 				val prefix = markerText?.let { "***[$it]*** " } ?: ""
 

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteNotifyCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteNotifyCommand.kt
@@ -4,7 +4,6 @@ import com.github.salomonbrys.kotson.*
 import com.google.gson.JsonElement
 import com.mrpowergamerbr.loritta.network.Databases
 import com.mrpowergamerbr.loritta.utils.Constants
-import com.mrpowergamerbr.loritta.utils.onReactionAddByAuthor
 import com.mrpowergamerbr.loritta.utils.stripCodeMarks
 import net.dv8tion.jda.api.EmbedBuilder
 import net.perfectdreams.loritta.api.commands.ArgumentType
@@ -53,9 +52,9 @@ class FortniteNotifyCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m
 				val embed = EmbedBuilder().setTitle("${Emotes.DEFAULT_DANCE} ${locale["${LOCALE_PREFIX}.itemsThatYouWantToBeNotified"]}")
 
 				for (tracked in alreadyTracking) {
-					val item = fortniteItemsInCurrentLocale.firstOrNull { tracked[TrackedFortniteItems.itemId] == it["itemId"].string } ?: continue
+					val item = fortniteItemsInCurrentLocale.firstOrNull { tracked[TrackedFortniteItems.itemId] == it["id"].string } ?: continue
 
-					embed.appendDescription("**${item["item"]["name"].string}**\n")
+					embed.appendDescription("**${item["name"].string}**\n")
 				}
 
 				embed.appendDescription("\n")
@@ -71,77 +70,45 @@ class FortniteNotifyCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m
 
 			val name = args.joinToString(" ")
 
-			val items = m.itemsInfo.values.flatMap {
-				it.filter {
-					it["itemId"].string == name || it["item"]["name"].nullString?.contains(name, true) == true
-				}
-			}.distinctBy { it["itemId"].string }
+			FortniteStuff.getFortniteItemByName(
+					m,
+					locale,
+					this,
+					name,
+					onSuccess = { element, message ->
+						message?.delete()?.queue()
 
-			val embed = EmbedBuilder()
-
-			if (items.size == 1) {
-				// Pegar na linguagem do usuário
-				val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { it["itemId"].string == items.first()["itemId"].string }
-
-				trackItem(this, fortniteItemInCurrentLocale)
-			} else if (items.isNotEmpty()) {
-				for (i in 0 until Math.min(9, items.size)) {
-					val item = items[i].obj
-					val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["itemId"].string == it["itemId"].string }["item"].obj
-
-					embed.setTitle("${Emotes.LORI_HM} ${locale["commands.fortnite.item.multipleItems"]}")
-					embed.setColor(Color(0, 125, 187))
-					embed.appendDescription("${Constants.INDEXES[i]} ${fortniteItemInCurrentLocale["name"].nullString} (${fortniteItemInCurrentLocale["typeName"].nullString})\n")
-				}
-
-				val result = sendMessage(getUserMention(true), embed.build())
-
-				result.onReactionAddByAuthor(this) {
-					val idx = Constants.INDEXES.indexOf(it.reactionEmote.name)
-
-					// Caso seja uma reaçõa inválida ou que não tem no metadata, ignore!
-					if (idx == -1 || (idx + 1) > items.size)
-						return@onReactionAddByAuthor
-
-					val item = items[idx]
-					val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["itemId"].string == it["itemId"].string }
-
-					result.delete().queue()
-
-					trackItem(this, fortniteItemInCurrentLocale)
-				}
-
-				// Adicionar os reactions
-				for (i in 0 until Math.min(9, items.size)) {
-					result.addReaction(Constants.INDEXES[i]).queue()
-				}
-			} else {
-				reply(
-						LorittaReply(
-								locale["commands.fortnite.item.unknownItem", "`${name.stripCodeMarks()}`"],
-								Constants.ERROR
+						trackItem(this, element)
+					},
+					onFailure = {
+						reply(
+								LorittaReply(
+										locale["$LOCALE_PREFIX.unknownItem", "`${name.stripCodeMarks()}`"],
+										Constants.ERROR
+								)
 						)
-				)
-			}
+					}
+			)
 		}
 	}
 
 	suspend fun trackItem(context: DiscordCommandContext, item: JsonElement) {
-		val itemWrapper = item["item"].obj
-		val isUpcoming = itemWrapper["upcoming"].bool
+		val itemWrapper = item.obj
 		val itemName = itemWrapper["name"].string
+		val source = itemWrapper["gameplayTags"].nullArray?.firstOrNull { it.string.startsWith("Cosmetics.Source") }
+				?.string
 
-		if ((itemWrapper["source"].nullString ?: "shop") == "shop") {
-			val alreadyTracking = transaction(Databases.loritta) {
+		if (source == "Cosmetics.Source.ItemShop") {
+			val alreadyTracking = loritta.newSuspendedTransaction {
 				TrackedFortniteItems.select {
-					(TrackedFortniteItems.trackedBy eq context.lorittaUser.profile.id) and (TrackedFortniteItems.itemId eq item["itemId"].string)
+					(TrackedFortniteItems.trackedBy eq context.lorittaUser.profile.id) and (TrackedFortniteItems.itemId eq item["id"].string)
 				}.count() != 0L
 			}
 
 			if (alreadyTracking) {
-				transaction(Databases.loritta) {
+				loritta.newSuspendedTransaction {
 					TrackedFortniteItems.deleteWhere {
-						(TrackedFortniteItems.trackedBy eq context.lorittaUser.profile.id) and (TrackedFortniteItems.itemId eq item["itemId"].string)
+						(TrackedFortniteItems.trackedBy eq context.lorittaUser.profile.id) and (TrackedFortniteItems.itemId eq item["id"].string)
 					}
 				}
 
@@ -154,10 +121,10 @@ class FortniteNotifyCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m
 				return
 			}
 
-			transaction(Databases.loritta) {
+			loritta.newSuspendedTransaction {
 				TrackedFortniteItems.insert {
 					it[trackedBy] = context.lorittaUser.profile.id
-					it[itemId] = item["itemId"].string
+					it[itemId] = item["id"].string
 				}
 			}
 
@@ -167,15 +134,6 @@ class FortniteNotifyCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m
 							Emotes.LORI_HAPPY
 					)
 			)
-
-			if (isUpcoming) {
-				replyList.add(
-						LorittaReply(
-								context.locale["${LOCALE_PREFIX}.upcomingItem"],
-								Emotes.LORI_HM
-						)
-				)
-			}
 
 			context.reply(
 					*replyList.toTypedArray()


### PR DESCRIPTION
A lot of commands broke because the API I was using is now unmaintained.

This changes the commands to use https://fortnite-api.com

**Stuff that will break:**
* The item IDs changed, so all notifications will be wiped.
* Can't get Team Rumble stats anymore

**Stuff that needs to be checked:**
* Item Shop notifications and broadcasts