### PR TITLE
Fix locale key in PagarCommand.kt

### DIFF
--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/PagarCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/PagarCommand.kt
@@ -131,7 +131,7 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 			if (howMuch.toBigDecimal() > balanceQuantity) {
 				context.reply(
                         LorittaReply(
-                                locale["commands.economy.pay..insufficientFunds", if (economySource == "global") locale["economy.currency.name.plural"] else economyConfig?.economyNamePlural],
+                                locale["commands.economy.pay.insufficientFunds", if (economySource == "global") locale["economy.currency.name.plural"] else economyConfig?.economyNamePlural],
                                 Constants.ERROR
                         )
 				)


### PR DESCRIPTION
If the user placed an amount of dreams above what he had at the time of transferring dreams, the loritta would return this: "!!{commands.economy.pay..insufficientFunds}!!"
