### PR TITLE
Loritta now uses the name of the role in the response

### DIFF
--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/listeners/MessageListener.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/listeners/MessageListener.kt
@@ -159,7 +159,7 @@ class MessageListener(val loritta: Loritta) : ListenerAdapter() {
 						if (ignoringCommandsRole == event.guild.publicRole)
 							response = locale["commands.mention.responseEveryoneBlocked", event.message.author.asMention, serverConfig.commandPrefix]
 						else
-							response = locale["commands.mention.responseRoleBlocked", event.message.author.asMention, serverConfig.commandPrefix, ignoringCommandsRole?.asMention]
+							response = locale["commands.mention.responseRoleBlocked", event.message.author.asMention, serverConfig.commandPrefix, "${ignoringCommandsRole?.name}"]
 					} else {
 						if (serverConfig.blacklistedChannels.contains(event.channel.idLong) && !lorittaUser.hasPermission(LorittaPermission.BYPASS_COMMAND_BLACKLIST)) {
 							// Vamos pegar um canal que seja possível usar comandos

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/listeners/MessageListener.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/listeners/MessageListener.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mu.KotlinLogging
+import net.dv8tion.jda.api.MessageBuilder
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.*
 import net.dv8tion.jda.api.events.message.MessageDeleteEvent
@@ -174,11 +175,16 @@ class MessageListener(val loritta: Loritta) : ListenerAdapter() {
 							}
 						}
 					}
+
+					val responseBuilder = MessageBuilder()
+						.setAllowedMentions(listOf(Message.MentionType.USER, Message.MentionType.CHANNEL))
+						.setContent("<:loritta:331179879582269451> **|** $response")
+
 					if (event.channel.canTalk()) {
-						event.channel.sendMessage("<:loritta:331179879582269451> **|** $response").queue()
+						event.channel.sendMessage(responseBuilder.build()).queue()
 					} else {
 						event.author.openPrivateChannel().queue {
-							it.sendMessage("<:loritta:331179879582269451> **|** $response").queue()
+							it.sendMessage(responseBuilder.build()).queue()
 						}
 					}
 				}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/listeners/MessageListener.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/listeners/MessageListener.kt
@@ -159,7 +159,7 @@ class MessageListener(val loritta: Loritta) : ListenerAdapter() {
 						if (ignoringCommandsRole == event.guild.publicRole)
 							response = locale["commands.mention.responseEveryoneBlocked", event.message.author.asMention, serverConfig.commandPrefix]
 						else
-							response = locale["commands.mention.responseRoleBlocked", event.message.author.asMention, serverConfig.commandPrefix, "${ignoringCommandsRole?.name}"]
+							response = locale["commands.mention.responseRoleBlocked", event.message.author.asMention, serverConfig.commandPrefix, "`${ignoringCommandsRole?.name}`"]
 					} else {
 						if (serverConfig.blacklistedChannels.contains(event.channel.idLong) && !lorittaUser.hasPermission(LorittaPermission.BYPASS_COMMAND_BLACKLIST)) {
 							// Vamos pegar um canal que seja possível usar comandos


### PR DESCRIPTION
This pull request fixes this issue: #2312 