### PR TITLE
Changes to locales related to commands

### DIFF
--- a/loritta-api/src/commonMain/kotlin/net/perfectdreams/loritta/api/commands/Command.kt
+++ b/loritta-api/src/commonMain/kotlin/net/perfectdreams/loritta/api/commands/Command.kt
@@ -20,8 +20,8 @@ open class Command<T : CommandContext>(
 ) {
 	companion object {
 		val MISSING_DESCRIPTION_KEY = LocaleKeyData("commands.missingDescription")
-		val SINGLE_IMAGE_EXAMPLES_KEY = LocaleKeyData("commands.images.singleImageExamples")
-		val TWO_IMAGES_EXAMPLES_KEY = LocaleKeyData("commands.images.twoImagesExamples")
+		val SINGLE_IMAGE_EXAMPLES_KEY = LocaleKeyData("commands.category.images.singleImageExamples")
+		val TWO_IMAGES_EXAMPLES_KEY = LocaleKeyData("commands.category.images.twoImagesExamples")
 	}
 
 	var needsToUploadFiles = false

--- a/loritta-api/src/commonMain/kotlin/net/perfectdreams/loritta/api/commands/CommandCategory.kt
+++ b/loritta-api/src/commonMain/kotlin/net/perfectdreams/loritta/api/commands/CommandCategory.kt
@@ -14,7 +14,7 @@ enum class CommandCategory {
 	ANIME,
 	DISCORD,
 	MISC,
-	ADMIN,
+	MODERATION,
 	UTILS,
 	SOCIAL,
 	ACTION,

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/AdminUtils.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/AdminUtils.kt
@@ -11,7 +11,11 @@ import com.mrpowergamerbr.loritta.utils.stripCodeMarks
 import com.mrpowergamerbr.loritta.utils.substringIfNeeded
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
-import net.dv8tion.jda.api.entities.*
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.User
 import net.perfectdreams.loritta.api.commands.ArgumentType
 import net.perfectdreams.loritta.api.commands.arguments
 import net.perfectdreams.loritta.api.messages.LorittaReply
@@ -29,7 +33,7 @@ import java.awt.Color
 import java.time.Instant
 
 object AdminUtils {
-	private val LOCALE_PREFIX = "commands.moderation"
+	private val LOCALE_PREFIX = "commands.category.moderation"
 	val PUNISHMENT_EXAMPLES_KEY = LocaleKeyData("$LOCALE_PREFIX.punishmentExamples")
 	val PUNISHMENT_USAGES = arguments {
 		argument(ArgumentType.USER) {
@@ -157,11 +161,11 @@ object AdminUtils {
 
 		if (!context.handle.canInteract(member)) {
 			val reply = buildString {
-				this.append(context.locale["commands.moderation.punisherRoleTooLow"])
+				this.append(context.locale["commands.category.moderation.punisherRoleTooLow"])
 
 				if (context.handle.hasPermission(Permission.MANAGE_ROLES)) {
 					this.append(" ")
-					this.append(context.locale["commands.moderation.punisherRoleTooLowHowToFix"])
+					this.append(context.locale["commands.category.moderation.punisherRoleTooLowHowToFix"])
 				}
 			}
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/BanCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/BanCommand.kt
@@ -15,7 +15,7 @@ import net.dv8tion.jda.api.entities.User
 import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.utils.PunishmentAction
 
-class BanCommand : AbstractCommand("ban", listOf("banir", "hackban", "forceban"), CommandCategory.ADMIN) {
+class BanCommand : AbstractCommand("ban", listOf("banir", "hackban", "forceban"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.ban.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/BanCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/BanCommand.kt
@@ -16,7 +16,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.utils.PunishmentAction
 
 class BanCommand : AbstractCommand("ban", listOf("banir", "hackban", "forceban"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.ban.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.ban.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES
 
@@ -83,7 +83,7 @@ class BanCommand : AbstractCommand("ban", listOf("banir", "hackban", "forceban")
 	}
 
 	companion object {
-		private val LOCALE_PREFIX = "commands.moderation"
+		private val LOCALE_PREFIX = "commands.command"
 
 		fun ban(settings: AdminUtils.ModerationConfigSettings, guild: Guild, punisher: User, locale: BaseLocale, user: User, reason: String, isSilent: Boolean, delDays: Int) {
 			if (!isSilent) {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/KickCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/KickCommand.kt
@@ -19,7 +19,7 @@ import net.perfectdreams.loritta.utils.Emotes
 import net.perfectdreams.loritta.utils.PunishmentAction
 
 class KickCommand : AbstractCommand("kick", listOf("expulsar", "kickar"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.kick.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.kick.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES
 
@@ -96,13 +96,13 @@ class KickCommand : AbstractCommand("kick", listOf("expulsar", "kickar"), Comman
 	}
 
 	companion object {
-		private val LOCALE_PREFIX = "commands.moderation"
+		private val LOCALE_PREFIX = "commands.command"
 
 		fun kick(context: CommandContext, settings: AdminUtils.ModerationConfigSettings, locale: BaseLocale, member: Member, user: User, reason: String, isSilent: Boolean) {
 			if (!isSilent) {
 				if (settings.sendPunishmentViaDm && context.guild.isMember(user)) {
 					try {
-						val embed = AdminUtils.createPunishmentMessageSentViaDirectMessage(context.guild, locale, context.userHandle, locale["commands.moderation.kick.punishAction"], reason)
+						val embed = AdminUtils.createPunishmentMessageSentViaDirectMessage(context.guild, locale, context.userHandle, locale["commands.command.kick.punishAction"], reason)
 
 						user.openPrivateChannel().queue {
 							it.sendMessage(embed).queue()
@@ -127,7 +127,7 @@ class KickCommand : AbstractCommand("kick", listOf("expulsar", "kickar"), Comman
 								listOf(user, context.guild),
 								context.guild,
 								mutableMapOf(
-										"duration" to locale["commands.moderation.mute.forever"]
+										"duration" to locale["commands.command.mute.forever"]
 								) + AdminUtils.getStaffCustomTokens(context.userHandle)
 										+ AdminUtils.getPunishmentCustomTokens(locale, reason, "${LOCALE_PREFIX}.kick")
 						)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/KickCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/KickCommand.kt
@@ -18,7 +18,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 import net.perfectdreams.loritta.utils.PunishmentAction
 
-class KickCommand : AbstractCommand("kick", listOf("expulsar", "kickar"), CommandCategory.ADMIN) {
+class KickCommand : AbstractCommand("kick", listOf("expulsar", "kickar"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.kick.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/LockCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/LockCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
-class LockCommand : AbstractCommand("lock", listOf("trancar", "fechar"), CommandCategory.ADMIN) {
+class LockCommand : AbstractCommand("lock", listOf("trancar", "fechar"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.lock.description")
 	
 	override fun getDiscordPermissions(): List<Permission> {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/LockCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/LockCommand.kt
@@ -12,7 +12,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
 class LockCommand : AbstractCommand("lock", listOf("trancar", "fechar"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.lock.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.lock.description")
 	
 	override fun getDiscordPermissions(): List<Permission> {
 		return listOf(Permission.MANAGE_SERVER)
@@ -40,14 +40,14 @@ class LockCommand : AbstractCommand("lock", listOf("trancar", "fechar"), Command
 
 				context.reply(
 					LorittaReply(
-						locale["commands.moderation.lock.denied", context.config.commandPrefix],
+						locale["commands.command.lock.denied", context.config.commandPrefix],
 						"\uD83C\uDF89"
 					)
 				)
 			} else {
 				context.reply(
 					LorittaReply(
-						locale["commands.moderation.lock.channelAlreadyIsLocked", context.config.commandPrefix],
+						locale["commands.command.lock.channelAlreadyIsLocked", context.config.commandPrefix],
 						Emotes.LORI_CRYING
 					)
 				)
@@ -59,7 +59,7 @@ class LockCommand : AbstractCommand("lock", listOf("trancar", "fechar"), Command
 
 			context.reply(
 				LorittaReply(
-					locale["commands.moderation.lock.denied", context.config.commandPrefix],
+					locale["commands.command.lock.denied", context.config.commandPrefix],
 					"\uD83C\uDF89"
 				)
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/MuteCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/MuteCommand.kt
@@ -28,7 +28,7 @@ import java.awt.Color
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
-class MuteCommand : AbstractCommand("mute", listOf("mutar", "silenciar"), CommandCategory.ADMIN) {
+class MuteCommand : AbstractCommand("mute", listOf("mutar", "silenciar"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.mute.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/MuteCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/MuteCommand.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 class MuteCommand : AbstractCommand("mute", listOf("mutar", "silenciar"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.mute.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.mute.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES
 
@@ -144,7 +144,7 @@ class MuteCommand : AbstractCommand("mute", listOf("mutar", "silenciar"), Comman
 	}
 
 	companion object {
-		private val LOCALE_PREFIX = "commands.moderation"
+		private val LOCALE_PREFIX = "commands.command"
 		private val logger = KotlinLogging.logger {}
 
 		// Para guardar as threads, a key deverá ser...
@@ -174,14 +174,14 @@ class MuteCommand : AbstractCommand("mute", listOf("mutar", "silenciar"), Comman
 			if (!isSilent) {
 				if (settings.sendPunishmentViaDm && context.guild.isMember(user)) {
 					try {
-						val embed = AdminUtils.createPunishmentEmbedBuilderSentViaDirectMessage(context.guild, locale, context.userHandle, locale["commands.moderation.mute.punishAction"], reason)
+						val embed = AdminUtils.createPunishmentEmbedBuilderSentViaDirectMessage(context.guild, locale, context.userHandle, locale["commands.command.mute.punishAction"], reason)
 
 						val timePretty = if (time != null)
 							DateUtils.formatDateDiff(System.currentTimeMillis(), time, locale)
-						else context.locale["commands.moderation.mute.forever"]
+						else context.locale["commands.command.mute.forever"]
 
 						embed.addField(
-								context.locale["commands.moderation.mute.duration"],
+								context.locale["commands.command.mute.duration"],
 								timePretty,
 								false
 						)
@@ -210,7 +210,7 @@ class MuteCommand : AbstractCommand("mute", listOf("mutar", "silenciar"), Comman
 										"duration" to if (delay != null) {
 											DateUtils.formatMillis(delay, locale)
 										} else {
-											locale["commands.moderation.mute.forever"]
+											locale["commands.command.mute.forever"]
 										}
 								) + AdminUtils.getStaffCustomTokens(context.userHandle)
 										+ AdminUtils.getPunishmentCustomTokens(locale, reason, "${LOCALE_PREFIX}.mute")
@@ -304,7 +304,7 @@ class MuteCommand : AbstractCommand("mute", listOf("mutar", "silenciar"), Comman
 			if (couldntEditChannels.isNotEmpty()) {
 				context.reply(
                         LorittaReply(
-                                context.locale["commands.moderation.mute.couldntEditChannel", couldntEditChannels.joinToString(", ", transform = { "`" + it.name.stripCodeMarks() + "`" })],
+                                context.locale["commands.command.mute.couldntEditChannel", couldntEditChannels.joinToString(", ", transform = { "`" + it.name.stripCodeMarks() + "`" })],
                                 Constants.ERROR
                         )
 				)
@@ -463,7 +463,7 @@ class MuteCommand : AbstractCommand("mute", listOf("mutar", "silenciar"), Comman
 							guild.selfMember.user,
 							locale,
 							currentMember.user,
-							locale["commands.moderation.unmute.automaticallyExpired", "<:lori_owo:417813932380520448>"],
+							locale["commands.command.unmute.automaticallyExpired", "<:lori_owo:417813932380520448>"],
 							false
 					)
 				}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/QuickPunishmentCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/QuickPunishmentCommand.kt
@@ -10,7 +10,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
 class QuickPunishmentCommand : AbstractCommand("quickpunishment", category = CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.quickpunishment.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.quickpunishment.description")
 
 	override fun canUseInPrivateChannel(): Boolean {
 		return false
@@ -22,10 +22,10 @@ class QuickPunishmentCommand : AbstractCommand("quickpunishment", category = Com
 		if (userData.quickPunishment) {
 			context.reply(
                     LorittaReply(
-                            message = locale["commands.moderation.quickpunishment.disabled"]
+                            message = locale["commands.command.quickpunishment.disabled"]
                     ),
 					LorittaReply(
-						message = locale["commands.moderation.quickpunishment.howEnable"],
+						message = locale["commands.command.quickpunishment.howEnable"],
 						prefix = Emotes.LORI_BAN_HAMMER,
 						mentionUser = false
 					)
@@ -33,10 +33,10 @@ class QuickPunishmentCommand : AbstractCommand("quickpunishment", category = Com
 		} else {
 			context.reply(
                     LorittaReply(
-                            message = locale["commands.moderation.quickpunishment.enabled"]
+                            message = locale["commands.command.quickpunishment.enabled"]
                     ),
 					LorittaReply(
-						message = locale["commands.moderation.quickpunishment.howDisable"],
+						message = locale["commands.command.quickpunishment.howDisable"],
 						prefix = Emotes.LORI_BAN_HAMMER,
 						mentionUser = false
 					)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/QuickPunishmentCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/QuickPunishmentCommand.kt
@@ -9,7 +9,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
-class QuickPunishmentCommand : AbstractCommand("quickpunishment", category = CommandCategory.ADMIN) {
+class QuickPunishmentCommand : AbstractCommand("quickpunishment", category = CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.quickpunishment.description")
 
 	override fun canUseInPrivateChannel(): Boolean {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/RoleIdCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/RoleIdCommand.kt
@@ -10,7 +10,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import java.util.*
 
 class RoleIdCommand : AbstractCommand("roleid", listOf("cargoid", "iddocargo"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.roleId.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.roleid.description")
 
 	// TODO: Fix getUsage
 
@@ -37,7 +37,7 @@ class RoleIdCommand : AbstractCommand("roleid", listOf("cargoid", "iddocargo"), 
 			if (mentionedRoles.isNotEmpty()) {
 
 				list.add(LorittaReply(
-                        message = locale["commands.moderation.roleId.identifiers", argument],
+                        message = locale["commands.command.roleid.identifiers", argument],
                         prefix = "\uD83D\uDCBC"
                 ))
 
@@ -51,14 +51,14 @@ class RoleIdCommand : AbstractCommand("roleid", listOf("cargoid", "iddocargo"), 
 				val roles = context.guild.roles.filter { it.name.contains(argument, true) }
 
 				list.add(LorittaReply(
-                        message = locale["commands.moderation.roleId.rolesThatContains", argument],
+                        message = locale["commands.command.roleid.rolesThatContains", argument],
                         prefix = "\uD83D\uDCBC"
                 ))
 
 				if (roles.isEmpty()) {
 					list.add(
                             LorittaReply(
-                                    message = "*${locale["commands.moderation.roleId.emptyRoles"]}*",
+                                    message = "*${locale["commands.command.roleid.emptyRoles"]}*",
                                     mentionUser = false,
                                     prefix = "\uD83D\uDE22"
                             )

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/RoleIdCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/RoleIdCommand.kt
@@ -9,7 +9,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 import java.util.*
 
-class RoleIdCommand : AbstractCommand("roleid", listOf("cargoid", "iddocargo"), CommandCategory.ADMIN) {
+class RoleIdCommand : AbstractCommand("roleid", listOf("cargoid", "iddocargo"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.roleid.description")
 
 	// TODO: Fix getUsage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/SayCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/SayCommand.kt
@@ -19,8 +19,8 @@ import net.perfectdreams.loritta.api.commands.arguments
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class SayCommand : AbstractCommand("say", listOf("falar"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.say.description")
-	override fun getExamplesKey()  = LocaleKeyData("commands.moderation.say.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.say.description")
+	override fun getExamplesKey()  = LocaleKeyData("commands.command.say.examples")
 	override fun getUsage() = arguments {
 		argument(ArgumentType.TEXT) {}
 	}
@@ -121,7 +121,7 @@ class SayCommand : AbstractCommand("say", listOf("falar"), CommandCategory.ADMIN
 			val watermarkedMessage = MessageUtils.watermarkMessage(
 					message,
 					context.userHandle,
-					context.locale["commands.discord.say.messageSentBy"]
+					context.locale["commands.command.say.messageSentBy"]
 			)
 
 			val discordMessage = try {
@@ -159,7 +159,7 @@ class SayCommand : AbstractCommand("say", listOf("falar"), CommandCategory.ADMIN
 			if (context.event.channel != channel && channel is TextChannel)
 				context.reply(
 						LorittaReply(
-								context.locale["commands.moderation.say.messageSuccessfullySent", channel.asMention],
+								context.locale["commands.command.say.messageSuccessfullySent", channel.asMention],
 								"\uD83C\uDF89"
 						)
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/SayCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/SayCommand.kt
@@ -18,7 +18,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.arguments
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
-class SayCommand : AbstractCommand("say", listOf("falar"), CommandCategory.ADMIN) {
+class SayCommand : AbstractCommand("say", listOf("falar"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.say.description")
 	override fun getExamplesKey()  = LocaleKeyData("commands.command.say.examples")
 	override fun getUsage() = arguments {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/SlowModeCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/SlowModeCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.CommandArguments
 import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.arguments
 
-class SlowModeCommand : AbstractCommand("slowmode", listOf("modolento"), CommandCategory.ADMIN) {
+class SlowModeCommand : AbstractCommand("slowmode", listOf("modolento"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.slowmode.description")
 
 	override fun getUsage(): CommandArguments {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/SlowModeCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/SlowModeCommand.kt
@@ -12,7 +12,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.arguments
 
 class SlowModeCommand : AbstractCommand("slowmode", listOf("modolento"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.slowmode.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.slowmode.description")
 
 	override fun getUsage(): CommandArguments {
 		return arguments {
@@ -22,7 +22,7 @@ class SlowModeCommand : AbstractCommand("slowmode", listOf("modolento"), Command
 		}
 	}
 
-	override fun getExamplesKey() = LocaleKeyData("commands.moderation.slowmode.examples")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.slowmode.examples")
 
 	override fun getDiscordPermissions(): List<Permission> {
 		return listOf(Permission.MESSAGE_MANAGE, Permission.MANAGE_CHANNEL)
@@ -49,7 +49,7 @@ class SlowModeCommand : AbstractCommand("slowmode", listOf("modolento"), Command
 				if (context.guild.selfMember.hasPermission(Permission.MANAGE_CHANNEL))
 					context.message.textChannel.manager.setSlowmode(0).queue()
 
-				context.sendMessage("\uD83C\uDFC3 **|** " + context.getAsMention(true) + context.locale["commands.moderation.slowmode.disabledInChannel", context.event.textChannel!!.asMention])
+				context.sendMessage("\uD83C\uDFC3 **|** " + context.getAsMention(true) + context.locale["commands.command.slowmode.disabledInChannel", context.event.textChannel!!.asMention])
 				return
 			}
 
@@ -61,7 +61,7 @@ class SlowModeCommand : AbstractCommand("slowmode", listOf("modolento"), Command
 				return
 			}
 
-			context.sendMessage("\uD83D\uDC0C **|** " + context.getAsMention(true) + context.locale["commands.moderation.slowmode.enabledInChannel", context.event.textChannel!!.asMention, seconds])
+			context.sendMessage("\uD83D\uDC0C **|** " + context.getAsMention(true) + context.locale["commands.command.slowmode.enabledInChannel", context.event.textChannel!!.asMention, seconds])
 		} else {
 			this.explain(context)
 		}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnbanCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnbanCommand.kt
@@ -18,7 +18,7 @@ import net.perfectdreams.loritta.utils.Emotes
 import net.perfectdreams.loritta.utils.PunishmentAction
 
 class UnbanCommand : AbstractCommand("unban", listOf("desbanir"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.unban.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.unban.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES
 
@@ -94,7 +94,7 @@ class UnbanCommand : AbstractCommand("unban", listOf("desbanir"), CommandCategor
 	}
 
 	companion object {
-		private const val LOCALE_PREFIX = "commands.moderation"
+		private const val LOCALE_PREFIX = "commands.command"
 
 		fun unban(settings: AdminUtils.ModerationConfigSettings, guild: Guild, punisher: User, locale: BaseLocale, user: User, reason: String, isSilent: Boolean) {
 			if (!isSilent) {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnbanCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnbanCommand.kt
@@ -17,7 +17,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 import net.perfectdreams.loritta.utils.PunishmentAction
 
-class UnbanCommand : AbstractCommand("unban", listOf("desbanir"), CommandCategory.ADMIN) {
+class UnbanCommand : AbstractCommand("unban", listOf("desbanir"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.unban.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnlockCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnlockCommand.kt
@@ -12,7 +12,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
 class UnlockCommand : AbstractCommand("unlock", listOf("destrancar"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.unlock.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.unlock.description")
 	
 	override fun getDiscordPermissions(): List<Permission> {
 		return listOf(Permission.MANAGE_SERVER)
@@ -40,14 +40,14 @@ class UnlockCommand : AbstractCommand("unlock", listOf("destrancar"), CommandCat
 
 				context.reply(
 					LorittaReply(
-						locale["commands.moderation.unlock.allowed", context.config.commandPrefix],
+						locale["commands.command.unlock.allowed", context.config.commandPrefix],
 						"\uD83C\uDF89"
 					)
 				)
 			} else {
 				context.reply(
 					LorittaReply(
-						locale["commands.moderation.unlock.channelAlreadyIsUnlocked", context.config.commandPrefix],
+						locale["commands.command.unlock.channelAlreadyIsUnlocked", context.config.commandPrefix],
 						Emotes.LORI_CRYING
 					)
 				)
@@ -59,7 +59,7 @@ class UnlockCommand : AbstractCommand("unlock", listOf("destrancar"), CommandCat
 
 			context.reply(
 				LorittaReply(
-					locale["commands.moderation.unlock.allowed", context.config.commandPrefix],
+					locale["commands.command.unlock.allowed", context.config.commandPrefix],
 					"\uD83C\uDF89"
 				)
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnlockCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnlockCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
-class UnlockCommand : AbstractCommand("unlock", listOf("destrancar"), CommandCategory.ADMIN) {
+class UnlockCommand : AbstractCommand("unlock", listOf("destrancar"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.unlock.description")
 	
 	override fun getDiscordPermissions(): List<Permission> {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnmuteCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnmuteCommand.kt
@@ -21,7 +21,7 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.transactions.transaction
 
-class UnmuteCommand : AbstractCommand("unmute", listOf("desmutar", "desilenciar", "desilenciar"), CommandCategory.ADMIN) {
+class UnmuteCommand : AbstractCommand("unmute", listOf("desmutar", "desilenciar", "desilenciar"), CommandCategory.MODERATION) {
 	override fun getDescriptionKey() = LocaleKeyData("commands.command.unmute.description")
 	override fun getExamplesKey() = LocaleKeyData("commands.command.unmute.examples")
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnmuteCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnmuteCommand.kt
@@ -22,8 +22,8 @@ import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class UnmuteCommand : AbstractCommand("unmute", listOf("desmutar", "desilenciar", "desilenciar"), CommandCategory.ADMIN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.unmute.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.moderation.unmute.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.unmute.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.unmute.examples")
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES
 
 	override fun getDiscordPermissions(): List<Permission> {
@@ -62,7 +62,7 @@ class UnmuteCommand : AbstractCommand("unmute", listOf("desmutar", "desilenciar"
 
 				context.reply(
                         LorittaReply(
-                                locale["commands.moderation.unmute.successfullyUnmuted"],
+                                locale["commands.command.unmute.successfullyUnmuted"],
                                 "\uD83C\uDF89"
                         )
 				)
@@ -110,9 +110,9 @@ class UnmuteCommand : AbstractCommand("unmute", listOf("desmutar", "desilenciar"
 								listOf(user, guild),
 								guild,
 								mutableMapOf(
-										"duration" to locale["commands.moderation.mute.forever"]
+										"duration" to locale["commands.command.mute.forever"]
 								) + AdminUtils.getStaffCustomTokens(punisher)
-										+ AdminUtils.getPunishmentCustomTokens(locale, reason, "commands.moderation.unmute")
+										+ AdminUtils.getPunishmentCustomTokens(locale, reason, "commands.command.unmute")
 						)
 
 						message?.let {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnwarnCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnwarnCommand.kt
@@ -18,7 +18,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 import org.jetbrains.exposed.sql.and
 
-class UnwarnCommand : AbstractCommand("unwarn", listOf("desavisar"), CommandCategory.ADMIN) {
+class UnwarnCommand : AbstractCommand("unwarn", listOf("desavisar"), CommandCategory.MODERATION) {
 	companion object {
 		private val LOCALE_PREFIX = "commands.command"
 	}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnwarnCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/UnwarnCommand.kt
@@ -20,11 +20,11 @@ import org.jetbrains.exposed.sql.and
 
 class UnwarnCommand : AbstractCommand("unwarn", listOf("desavisar"), CommandCategory.ADMIN) {
 	companion object {
-		private val LOCALE_PREFIX = "commands.moderation"
+		private val LOCALE_PREFIX = "commands.command"
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.unwarn.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.moderation.unwarn.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.unwarn.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.unwarn.examples")
 
 	override fun getUsage(): CommandArguments {
 		return arguments {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/WarnCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/WarnCommand.kt
@@ -21,7 +21,7 @@ import net.perfectdreams.loritta.utils.PunishmentAction
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.select
 
-class WarnCommand : AbstractCommand("warn", listOf("aviso"), CommandCategory.ADMIN) {
+class WarnCommand : AbstractCommand("warn", listOf("aviso"), CommandCategory.MODERATION) {
 	companion object {
 		private val LOCALE_PREFIX = "commands.command"
 	}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/WarnCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/WarnCommand.kt
@@ -23,10 +23,10 @@ import org.jetbrains.exposed.sql.select
 
 class WarnCommand : AbstractCommand("warn", listOf("aviso"), CommandCategory.ADMIN) {
 	companion object {
-		private val LOCALE_PREFIX = "commands.moderation"
+		private val LOCALE_PREFIX = "commands.command"
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.moderation.warn.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.warn.description")
 	override fun getExamplesKey() = AdminUtils.PUNISHMENT_EXAMPLES_KEY
 	override fun getUsage() = AdminUtils.PUNISHMENT_USAGES
 
@@ -65,7 +65,7 @@ class WarnCommand : AbstractCommand("warn", listOf("aviso"), CommandCategory.ADM
 					if (!isSilent) {
 						if (settings.sendPunishmentViaDm && context.guild.isMember(user)) {
 							try {
-								val embed = AdminUtils.createPunishmentMessageSentViaDirectMessage(context.guild, locale, context.userHandle, locale["commands.moderation.warn.punishAction"], reason)
+								val embed = AdminUtils.createPunishmentMessageSentViaDirectMessage(context.guild, locale, context.userHandle, locale["commands.command.warn.punishAction"], reason)
 
 								user.openPrivateChannel().queue {
 									it.sendMessage(embed).queue()

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/WarnListCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/WarnListCommand.kt
@@ -18,7 +18,7 @@ import net.perfectdreams.loritta.api.commands.arguments
 import net.perfectdreams.loritta.utils.PunishmentAction
 import org.jetbrains.exposed.sql.and
 
-class WarnListCommand : AbstractCommand("punishmentlist", listOf("listadeavisos", "modlog", "modlogs", "infractions", "warnlist", "warns"), CommandCategory.ADMIN) {
+class WarnListCommand : AbstractCommand("punishmentlist", listOf("listadeavisos", "modlog", "modlogs", "infractions", "warnlist", "warns"), CommandCategory.MODERATION) {
 	companion object {
 		private val LOCALE_PREFIX = "commands.command"
 	}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/WarnListCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/administration/WarnListCommand.kt
@@ -20,7 +20,7 @@ import org.jetbrains.exposed.sql.and
 
 class WarnListCommand : AbstractCommand("punishmentlist", listOf("listadeavisos", "modlog", "modlogs", "infractions", "warnlist", "warns"), CommandCategory.ADMIN) {
 	companion object {
-		private val LOCALE_PREFIX = "commands.moderation"
+		private val LOCALE_PREFIX = "commands.command"
 	}
 
 	override fun getDescriptionKey() = LocaleKeyData("$LOCALE_PREFIX.warnlist.description")

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/AddEmojiCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/AddEmojiCommand.kt
@@ -28,7 +28,7 @@ class AddEmojiCommand : AbstractCommand("addemoji", listOf("adicionaremoji", "cr
 		}
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.addemoji.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.addemoji.description")
 
 	override fun getDiscordPermissions(): List<Permission> {
 		return listOf(Permission.MANAGE_EMOTES)
@@ -65,7 +65,7 @@ class AddEmojiCommand : AbstractCommand("addemoji", listOf("adicionaremoji", "cr
 					val emote = context.guild.createEmote(emoteName, Icon.from(inputStream)).await()
 					context.reply(
                             LorittaReply(
-                                    context.locale["commands.discord.addemoji.success"],
+                                    context.locale["commands.command.addemoji.success"],
                                     emote.asMention
                             )
 					)
@@ -78,7 +78,7 @@ class AddEmojiCommand : AbstractCommand("addemoji", listOf("adicionaremoji", "cr
 				if (e.errorCode == 30008) {
 					context.reply(
                             LorittaReply(
-                                    context.locale["commands.discord.addemoji.limitReached"],
+                                    context.locale["commands.command.addemoji.limitReached"],
                                     Constants.ERROR
                             )
 					)
@@ -87,7 +87,7 @@ class AddEmojiCommand : AbstractCommand("addemoji", listOf("adicionaremoji", "cr
 				if (e.errorCode == 400) {
 					context.reply(
                             LorittaReply(
-                                    context.locale["commands.discord.addemoji.emoteTooBig", "`256kb`"],
+                                    context.locale["commands.command.addemoji.emoteTooBig", "`256kb`"],
                                     Constants.ERROR
                             )
 					)
@@ -97,7 +97,7 @@ class AddEmojiCommand : AbstractCommand("addemoji", listOf("adicionaremoji", "cr
 
 			context.reply(
                     LorittaReply(
-                            context.locale["commands.discord.addemoji.error"],
+                            context.locale["commands.command.addemoji.error"],
                             Constants.ERROR
                     )
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/AvatarCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/AvatarCommand.kt
@@ -19,10 +19,10 @@ import java.util.*
 
 class AvatarCommand : AbstractCommand("avatar", category = CommandCategory.DISCORD) {
 	companion object {
-		const val LOCALE_PREFIX = "commands.discord.avatar"
+		const val LOCALE_PREFIX = "commands.command.avatar"
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.avatar.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.avatar.description")
 
 	override fun getUsage(): CommandArguments {
 		return arguments {
@@ -32,7 +32,7 @@ class AvatarCommand : AbstractCommand("avatar", category = CommandCategory.DISCO
 		}
 	}
 
-	override fun getExamplesKey() = LocaleKeyData("commands.discord.avatar.examples")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.avatar.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		var getAvatar = context.getUserAt(0)
@@ -74,7 +74,7 @@ class AvatarCommand : AbstractCommand("avatar", category = CommandCategory.DISCO
 
 					val displayName = fancyName ?: user?.name
 
-					embed.appendDescription("\n\n**" + locale["commands.misc.fanArts.madeBy", displayName] + "**")
+					embed.appendDescription("\n\n**" + locale["commands.command.fanarts.madeBy", displayName] + "**")
 					// TODO: Readicionar redes sociais depois
 					/* val artist = loritta.fanArtArtists.firstOrNull {
 						it.socialNetworks

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/BotInfoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/BotInfoCommand.kt
@@ -24,7 +24,7 @@ import java.util.jar.Attributes
 import java.util.jar.JarFile
 
 class BotInfoCommand(private val buildInfo: BuildInfo) : AbstractCommand("botinfo", category = CommandCategory.DISCORD) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.botinfo.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.botinfo.description")
 
 	override suspend fun run(context: CommandContext, locale: BaseLocale) {
 		val arg0 = context.rawArgs.getOrNull(0)
@@ -63,12 +63,12 @@ class BotInfoCommand(private val buildInfo: BuildInfo) : AbstractCommand("botinf
 			}.count()
 		}
 
-		embed.setAuthor("${context.locale["commands.discord.botinfo.title"]} 💁", loritta.instanceConfig.loritta.website.url, "${loritta.instanceConfig.loritta.website.url}assets/img/loritta_gabizinha_v1.png")
+		embed.setAuthor("${context.locale["commands.command.botinfo.title"]} 💁", loritta.instanceConfig.loritta.website.url, "${loritta.instanceConfig.loritta.website.url}assets/img/loritta_gabizinha_v1.png")
 		embed.setThumbnail("${loritta.instanceConfig.loritta.website.url}assets/img/loritta_gabizinha_v1.png")
 		embed.setColor(Color(0, 193, 223))
 		embed.setDescription(
 				context.locale.getList(
-						"commands.discord.botinfo.embedDescription",
+						"commands.command.botinfo.embedDescription",
 						guildCount,
 						sb.toString(),
 						LorittaLauncher.loritta.legacyCommandManager.commandMap.size + loritta.commandMap.commands.size,
@@ -85,7 +85,7 @@ class BotInfoCommand(private val buildInfo: BuildInfo) : AbstractCommand("botinf
 		embed.addField("<:loritta:331179879582269451> ${context.locale["website.jumbotron.addMe"]}", "${loritta.instanceConfig.loritta.website.url}dashboard", true)
 		embed.addField("<:lori_ok_hand:426183783008698391> ${context.locale["modules.sectionNames.commands"]}", "${loritta.instanceConfig.loritta.website.url}commands", true)
 		embed.addField("\uD83D\uDC81 ${context.locale["website.support.title"]}", "${loritta.instanceConfig.loritta.website.url}support", true)
-		embed.addField(locale["commands.discord.botinfo.crowdin"], loritta.config.crowdin.url, true)
+		embed.addField(locale["commands.command.botinfo.crowdin"], loritta.config.crowdin.url, true)
 		embed.addField("<:twitter:552840901886738433> Twitter", "[@LorittaBot](https://twitter.com/LorittaBot)", true)
 		embed.addField("<:instagram:552841049660325908> Instagram", "[@lorittabot](https://instagram.com/lorittabot/)", true)
 
@@ -97,9 +97,9 @@ class BotInfoCommand(private val buildInfo: BuildInfo) : AbstractCommand("botinf
 		}
 
 		embed.addField(
-				"\uD83C\uDFC5 ${locale["commands.discord.botinfo.honorableMentionsTitle"]}",
+				"\uD83C\uDFC5 ${locale["commands.command.botinfo.honorableMentionsTitle"]}",
 				locale.getList(
-						"commands.discord.botinfo.honorableMentions",
+						"commands.command.botinfo.honorableMentions",
 						numberOfUniqueDonators,
 						loritta.fanArtArtists.size,
 						context.userHandle.asMention,
@@ -112,7 +112,7 @@ class BotInfoCommand(private val buildInfo: BuildInfo) : AbstractCommand("botinf
 				false
 		)
 
-		embed.setFooter("${locale["commands.discord.botinfo.lorittaCreatedBy"]} - https://mrpowergamerbr.com/", lorittaShards.retrieveUserById(123170274651668480L)!!.effectiveAvatarUrl)
+		embed.setFooter("${locale["commands.command.botinfo.lorittaCreatedBy"]} - https://mrpowergamerbr.com/", lorittaShards.retrieveUserById(123170274651668480L)!!.effectiveAvatarUrl)
 
 		val message = context.sendMessage(context.getAsMention(true), embed.build())
 
@@ -156,12 +156,12 @@ class BotInfoCommand(private val buildInfo: BuildInfo) : AbstractCommand("botinf
                         prefix = "<:loritta:331179879582269451>"
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.lorittaVersion"]}:** $lorittaVersion",
+                        "**${locale["commands.command.botinfo.lorittaVersion"]}:** $lorittaVersion",
                         "\uD83D\uDD16",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.buildNumber"]}:** #$buildNumber <$buildURL>",
+                        "**${locale["commands.command.botinfo.buildNumber"]}:** #$buildNumber <$buildURL>",
                         "\uD83C\uDFD7",
                         mentionUser = false
                 ),
@@ -176,57 +176,57 @@ class BotInfoCommand(private val buildInfo: BuildInfo) : AbstractCommand("botinf
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.compiledAt"]}:** $compiledAt",
+                        "**${locale["commands.command.botinfo.compiledAt"]}:** $compiledAt",
                         "⏰",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.javaVersion"]}:** ${System.getProperty("java.version")}",
+                        "**${locale["commands.command.botinfo.javaVersion"]}:** ${System.getProperty("java.version")}",
                         "<:java:467443707160035329>",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.kotlinVersion"]}:** $kotlinVersion",
+                        "**${locale["commands.command.botinfo.kotlinVersion"]}:** $kotlinVersion",
                         "<:kotlin:453714186925637642>",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.jdaVersion"]}:** $jdaVersion",
+                        "**${locale["commands.command.botinfo.jdaVersion"]}:** $jdaVersion",
                         "<:jda:411518264267767818>",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.memoryUsed"]}:** $usedMemory MB",
+                        "**${locale["commands.command.botinfo.memoryUsed"]}:** $usedMemory MB",
                         "\uD83D\uDCBB",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.memoryAvailable"]}:** $freeMemory MB",
+                        "**${locale["commands.command.botinfo.memoryAvailable"]}:** $freeMemory MB",
                         "\uD83D\uDCBB",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.memoryAllocated"]}:** $totalMemory MB",
+                        "**${locale["commands.command.botinfo.memoryAllocated"]}:** $totalMemory MB",
                         "\uD83D\uDCBB",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.memoryTotal"]}:** $maxMemory MB",
+                        "**${locale["commands.command.botinfo.memoryTotal"]}:** $maxMemory MB",
                         "\uD83D\uDCBB",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.threadCount"]}:** ${ManagementFactory.getThreadMXBean().threadCount}",
+                        "**${locale["commands.command.botinfo.threadCount"]}:** ${ManagementFactory.getThreadMXBean().threadCount}",
                         "\uD83D\uDC4B",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.environment"]}:** ${loritta.config.loritta.environment.name}",
+                        "**${locale["commands.command.botinfo.environment"]}:** ${loritta.config.loritta.environment.name}",
                         "\uD83C\uDF43",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        "**${locale["commands.discord.botinfo.love"]}:** ∞",
+                        "**${locale["commands.command.botinfo.love"]}:** ∞",
                         "<:blobheart:467447056374693889>",
                         mentionUser = false
                 )

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/ChannelInfoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/ChannelInfoCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractComman
 
 class ChannelInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("channelinfo", "channel"), CommandCategory.DISCORD) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.discord"
+		private const val LOCALE_PREFIX = "commands.command"
 	}
 
 	override fun command() = create {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/EmojiCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/EmojiCommand.kt
@@ -17,7 +17,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
 class EmojiCommand : AbstractCommand("emoji", category = CommandCategory.DISCORD) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.emoji.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.emoji.description")
 
 	// TODO: Fix Usage
 
@@ -48,7 +48,7 @@ class EmojiCommand : AbstractCommand("emoji", category = CommandCategory.DISCORD
 				} else {
 					context.reply(
                             LorittaReply(
-                                    locale["commands.discord.emoji.notFoundId", "`$arg0`"],
+                                    locale["commands.command.emoji.notFoundId", "`$arg0`"],
                                     Constants.ERROR
                             )
 					)
@@ -72,7 +72,7 @@ class EmojiCommand : AbstractCommand("emoji", category = CommandCategory.DISCORD
 					if (HttpRequest.get("https://twemoji.maxcdn.com/2/72x72/$value.png").code() != 200) {
 						context.reply(
                                 LorittaReply(
-                                        context.locale["commands.discord.emoji.errorWhileDownloadingEmoji", Emotes.LORI_SHRUG],
+                                        context.locale["commands.command.emoji.errorWhileDownloadingEmoji", Emotes.LORI_SHRUG],
                                         Constants.ERROR
                                 )
 						)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/EmojiInfoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/EmojiInfoCommand.kt
@@ -20,7 +20,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import kotlin.streams.toList
 
 class EmojiInfoCommand : AbstractCommand("emojiinfo", category = CommandCategory.DISCORD) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.emojiinfo.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.emojiinfo.description")
 
 	override fun getUsage(): CommandArguments {
 		return arguments {
@@ -47,7 +47,7 @@ class EmojiInfoCommand : AbstractCommand("emojiinfo", category = CommandCategory
 				} else {
 					context.reply(
                             LorittaReply(
-                                    locale["commands.discord.emoji.notFoundId", "`$arg0`"],
+                                    locale["commands.command.emoji.notFoundId", "`$arg0`"],
                                     Constants.ERROR
                             )
 					)
@@ -73,7 +73,7 @@ class EmojiInfoCommand : AbstractCommand("emojiinfo", category = CommandCategory
 
 				val embed = EmbedBuilder()
 				embed.setColor(Constants.DISCORD_BLURPLE)
-				embed.setTitle("$arg0 ${context.locale["commands.discord.emojiinfo.aboutEmoji"]}")
+				embed.setTitle("$arg0 ${context.locale["commands.command.emojiinfo.aboutEmoji"]}")
 				embed.setThumbnail(emojiUrl)
 
 				val names = mutableListOf<String>()
@@ -84,9 +84,9 @@ class EmojiInfoCommand : AbstractCommand("emojiinfo", category = CommandCategory
 				}
 
 				if (names.isNotEmpty())
-					embed.addField("\uD83D\uDD16 ${context.locale["commands.discord.emojiinfo.emojiName"]}", "`${names.joinToString(" + ")}`", true)
+					embed.addField("\uD83D\uDD16 ${context.locale["commands.command.emojiinfo.emojiName"]}", "`${names.joinToString(" + ")}`", true)
 
-				embed.addField("\uD83D\uDC40 ${context.locale["commands.discord.emojiinfo.mention"]}", "`$arg0`", true)
+				embed.addField("\uD83D\uDC40 ${context.locale["commands.command.emojiinfo.mention"]}", "`$arg0`", true)
 				embed.addField("\uD83D\uDCBB Unicode", "`${codePoints.map { "\\$it" }.joinToString("")}`", true)
 				embed.addField("⛓ Link", emojiUrl, true)
 
@@ -118,14 +118,14 @@ class EmojiInfoCommand : AbstractCommand("emojiinfo", category = CommandCategory
 				"✨"
 			val embed = EmbedBuilder()
 			embed.setColor(Constants.DISCORD_BLURPLE)
-			embed.setTitle("$emoteTitle ${context.locale["commands.discord.emojiinfo.aboutEmoji"]}")
+			embed.setTitle("$emoteTitle ${context.locale["commands.command.emojiinfo.aboutEmoji"]}")
 			embed.setThumbnail(emote.imageUrl)
-			embed.addField("\uD83D\uDD16 ${context.locale["commands.discord.emojiinfo.emojiName"]}", "`${emote.name}`", true)
-			embed.addField("\uD83D\uDCBB ${context.locale["commands.discord.emojiinfo.emojiId"]}", "`${emote.id}`", true)
-			embed.addField("\uD83D\uDC40 ${context.locale["commands.discord.emojiinfo.mention"]}", "`${emote.asMention}`", true)
-			embed.addField("\uD83D\uDCC5 ${context.locale["commands.discord.emojiinfo.emojiCreated"]}", DateUtils.formatDateDiff(emote.timeCreated.toInstant().toEpochMilli(), context.locale), true)
+			embed.addField("\uD83D\uDD16 ${context.locale["commands.command.emojiinfo.emojiName"]}", "`${emote.name}`", true)
+			embed.addField("\uD83D\uDCBB ${context.locale["commands.command.emojiinfo.emojiId"]}", "`${emote.id}`", true)
+			embed.addField("\uD83D\uDC40 ${context.locale["commands.command.emojiinfo.mention"]}", "`${emote.asMention}`", true)
+			embed.addField("\uD83D\uDCC5 ${context.locale["commands.command.emojiinfo.emojiCreated"]}", DateUtils.formatDateDiff(emote.timeCreated.toInstant().toEpochMilli(), context.locale), true)
 			if (sourceGuild != null)
-				embed.addField("\uD83D\uDD0E ${context.locale["commands.discord.emojiinfo.seenAt"]}", "`${sourceGuild.name}`", true)
+				embed.addField("\uD83D\uDD0E ${context.locale["commands.command.emojiinfo.seenAt"]}", "`${sourceGuild.name}`", true)
 			embed.addField("⛓ Link", emote.imageUrl + "?size=2048", true)
 			return embed.build()
 		}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/InviteCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/InviteCommand.kt
@@ -10,11 +10,11 @@ import net.dv8tion.jda.api.EmbedBuilder
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class InviteCommand : AbstractCommand("invite", listOf("convidar", "convidarbot", "invitebot", "convite"), CommandCategory.DISCORD) {
-    override fun getDescriptionKey() = LocaleKeyData("commands.discord.invite.info")
+    override fun getDescriptionKey() = LocaleKeyData("commands.command.invite.info")
 
     override suspend fun run(context: CommandContext,locale: BaseLocale) {
         var embed = EmbedBuilder()
-                .setDescription(context.locale.getList("commands.discord.invite.inviteInfo", loritta.discordInstanceConfig.discord.addBotUrl, "${loritta.instanceConfig.loritta.website.url}dashboard", "${loritta.instanceConfig.loritta.website.url}support").joinToString("\n"))
+                .setDescription(context.locale.getList("commands.command.invite.inviteInfo", loritta.discordInstanceConfig.discord.addBotUrl, "${loritta.instanceConfig.loritta.website.url}dashboard", "${loritta.instanceConfig.loritta.website.url}support").joinToString("\n"))
                 .setThumbnail("${loritta.instanceConfig.loritta.website.url}assets/img/loritta_gabizinha_v1.png")
                 .setColor(Constants.LORITTA_AQUA)
                 .build()

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/InviteInfoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/InviteInfoCommand.kt
@@ -22,8 +22,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class InviteInfoCommand : AbstractCommand("inviteinfo", category = CommandCategory.DISCORD) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.inviteinfo.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.discord.inviteinfo.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.inviteinfo.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.inviteinfo.examples")
 
 	// TODO: Fix Usage
 
@@ -55,7 +55,7 @@ class InviteInfoCommand : AbstractCommand("inviteinfo", category = CommandCatego
 				// Invite não existe!
 				context.reply(
 						LorittaReply(
-								context.locale["commands.discord.inviteinfo.doesntExists", inviteId.stripCodeMarks()],
+								context.locale["commands.command.inviteinfo.doesntExists", inviteId.stripCodeMarks()],
 								Constants.ERROR
 						)
 				)
@@ -78,13 +78,13 @@ class InviteInfoCommand : AbstractCommand("inviteinfo", category = CommandCatego
 				embed.setTitle("<:discord:314003252830011395> $name", null) // Nome da Guild
 
 				embed.addField("💻 ID", id, true) // ID da Guild
-				embed.addField("\uD83D\uDC6E ${locale["commands.discord.serverinfo.verificationLevel"]}", verificationLevel.toString(), true) // ID da Guild
-				embed.addField("\uD83D\uDC65 ${locale["commands.discord.serverinfo.members"]}", "\uD83D\uDC81 **${locale["commands.discord.inviteinfo.active"]}:** ${approxPresenceCount}\n\uD83D\uDE34 **Offline:** $approxMemberCount", true)
+				embed.addField("\uD83D\uDC6E ${locale["commands.command.serverinfo.verificationLevel"]}", verificationLevel.toString(), true) // ID da Guild
+				embed.addField("\uD83D\uDC65 ${locale["commands.command.serverinfo.members"]}", "\uD83D\uDC81 **${locale["commands.command.inviteinfo.active"]}:** ${approxPresenceCount}\n\uD83D\uDE34 **Offline:** $approxMemberCount", true)
 
 				if (features.size() == 0) {
-					embed.addField("✨ ${locale["commands.discord.serverinfo.features"]}", locale["commands.discord.inviteinfo.none"], true) // ID da Guild
+					embed.addField("✨ ${locale["commands.command.serverinfo.features"]}", locale["commands.command.inviteinfo.none"], true) // ID da Guild
 				} else {
-					embed.addField("✨ ${locale["commands.discord.serverinfo.features"]}", features.joinToString(", ", transform = { it.string }), true) // ID da Guild
+					embed.addField("✨ ${locale["commands.command.serverinfo.features"]}", features.joinToString(", ", transform = { it.string }), true) // ID da Guild
 				}
 
 				if (icon != null) {
@@ -95,22 +95,22 @@ class InviteInfoCommand : AbstractCommand("inviteinfo", category = CommandCatego
 					embed.setImage("https://cdn.discordapp.com/splashes/$id/$splash.png?size=1024")
 				}
 
-				embed.addField("\uD83D\uDDE3 ${locale["commands.discord.inviteinfo.channelInvite"]}", "`#${channel["name"].string}` (${channel["id"].string})", true)
+				embed.addField("\uD83D\uDDE3 ${locale["commands.command.inviteinfo.channelInvite"]}", "`#${channel["name"].string}` (${channel["id"].string})", true)
 
 				if (inviter != null) {
 					val username = inviter["username"].string
 					val discriminator = inviter["discriminator"].string
 					val id = inviter["id"].string
 
-					embed.addField("\uD83D\uDC4B ${locale["commands.discord.inviteinfo.whoInvited"]}", "`$username#$discriminator` ($id)", true)
+					embed.addField("\uD83D\uDC4B ${locale["commands.command.inviteinfo.whoInvited"]}", "`$username#$discriminator` ($id)", true)
 				}
 
 				val discordGuild = lorittaShards.queryGuildById(id)
 
 				if (discordGuild != null) {
-					embed.setFooter("\uD83D\uDE0A ${context.locale["commands.discord.inviteinfo.inThisServer"]}")
+					embed.setFooter("\uD83D\uDE0A ${context.locale["commands.command.inviteinfo.inThisServer"]}")
 				} else {
-					embed.setFooter("\uD83D\uDE2D ${context.locale["commands.discord.inviteinfo.notOnTheServer"]}")
+					embed.setFooter("\uD83D\uDE2D ${context.locale["commands.command.inviteinfo.notOnTheServer"]}")
 				}
 
 				context.sendMessage(context.getAsMention(true), embed.build()) // phew, agora finalmente poderemos enviar o embed!

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/RemoveEmojiCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/RemoveEmojiCommand.kt
@@ -12,7 +12,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 class RemoveEmojiCommand : AbstractCommand("removeemoji", listOf("deleteemoji", "deletaremoji", "removeremoji", "delemoji"), CommandCategory.DISCORD) {
 	// TODO: Fix Usage
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.removeemoji.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.removeemoji.description")
 
 	override fun getDiscordPermissions(): List<Permission> {
 		return listOf(Permission.MANAGE_EMOTES)
@@ -35,7 +35,7 @@ class RemoveEmojiCommand : AbstractCommand("removeemoji", listOf("deleteemoji", 
 		if (deletedEmotes != 0) {
 			context.reply(
                     LorittaReply(
-                            locale["commands.discord.removeemoji.success", deletedEmotes, if (deletedEmotes == 1) "emoji" else "emojis"],
+                            locale["commands.command.removeemoji.success", deletedEmotes, if (deletedEmotes == 1) "emoji" else "emojis"],
                             "\uD83D\uDDD1"
                     )
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/ServerIconCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/ServerIconCommand.kt
@@ -16,7 +16,7 @@ import net.perfectdreams.loritta.utils.Emotes
 
 class ServerIconCommand : AbstractCommand("servericon", listOf("guildicon", "iconeserver", "iconeguild", "iconedoserver", "iconedaguild", "íconedoserver", "iconedoservidor", "íconeguild", "íconedoserver", "íconedaguild", "íconedoservidor"), category = CommandCategory.DISCORD) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.discord.servericon"
+		private const val LOCALE_PREFIX = "commands.command.servericon"
 	}
 
 	override fun getDescriptionKey() = LocaleKeyData("$LOCALE_PREFIX.description")

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/ServerInfoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/ServerInfoCommand.kt
@@ -24,7 +24,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.DiscordUtils
 
 class ServerInfoCommand : AbstractCommand("serverinfo", listOf("guildinfo"), category = CommandCategory.DISCORD) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.serverinfo.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.serverinfo.description")
 
 	override fun canUseInPrivateChannel(): Boolean {
 		return false
@@ -47,7 +47,7 @@ class ServerInfoCommand : AbstractCommand("serverinfo", listOf("guildinfo"), cat
 		if (guild == null) {
 			context.reply(
                     LorittaReply(
-                            message = context.locale["commands.discord.serverinfo.unknownGuild", context.args[0]],
+                            message = context.locale["commands.command.serverinfo.unknownGuild", context.args[0]],
                             prefix = Constants.ERROR
                     )
 			)
@@ -78,14 +78,14 @@ class ServerInfoCommand : AbstractCommand("serverinfo", listOf("guildinfo"), cat
 		embed.setTitle("<:discord:314003252830011395> $name", null) // Nome da Guild
 		embed.addField("💻 ID", id, true) // ID da Guild
 		embed.addField("\uD83D\uDCBB Shard ID", "$shardId — Loritta Cluster ${cluster.id} (`${cluster.name}`)", true)
-		embed.addField("👑 ${if (ownerGender == Gender.MALE) context.locale["commands.discord.serverinfo.owner"] else context.locale["commands.discord.serverinfo.ownerFemale"]}", "`${owner?.name}#${owner?.discriminator}` (${ownerId})", true) // Dono da Guild
-		embed.addField("🌎 ${context.locale["commands.discord.serverinfo.region"]}", region.getName(), true) // Região da Guild
-		embed.addField("\uD83D\uDCAC ${context.locale["commands.discord.serverinfo.channels"]} (${textChannelCount + voiceChannelCount})", "\uD83D\uDCDD **${locale["commands.discord.serverinfo.textChannels"]}:** ${textChannelCount}\n\uD83D\uDDE3 **${locale["commands.discord.serverinfo.voiceChannels"]}:** $voiceChannelCount", true) // Canais da Guild
+		embed.addField("👑 ${if (ownerGender == Gender.MALE) context.locale["commands.command.serverinfo.owner"] else context.locale["commands.command.serverinfo.ownerFemale"]}", "`${owner?.name}#${owner?.discriminator}` (${ownerId})", true) // Dono da Guild
+		embed.addField("🌎 ${context.locale["commands.command.serverinfo.region"]}", region.getName(), true) // Região da Guild
+		embed.addField("\uD83D\uDCAC ${context.locale["commands.command.serverinfo.channels"]} (${textChannelCount + voiceChannelCount})", "\uD83D\uDCDD **${locale["commands.command.serverinfo.textChannels"]}:** ${textChannelCount}\n\uD83D\uDDE3 **${locale["commands.command.serverinfo.voiceChannels"]}:** $voiceChannelCount", true) // Canais da Guild
 		val createdAtDiff = DateUtils.formatDateDiff(timeCreated, locale)
-		embed.addField("\uD83D\uDCC5 ${context.locale["commands.discord.serverinfo.createdAt"]}", "${timeCreated.humanize(locale)} ($createdAtDiff)", true)
+		embed.addField("\uD83D\uDCC5 ${context.locale["commands.command.serverinfo.createdAt"]}", "${timeCreated.humanize(locale)} ($createdAtDiff)", true)
 		val joinedAtDiff = DateUtils.formatDateDiff(timeJoined, locale)
-		embed.addField("\uD83C\uDF1F ${context.locale["commands.discord.serverinfo.joinedAt"]}", "${timeJoined.humanize(locale)} ($joinedAtDiff)", true)
-		embed.addField("👥 ${context.locale["commands.discord.serverinfo.members"]} ($memberCount)", "", true) // Membros da Guild
+		embed.addField("\uD83C\uDF1F ${context.locale["commands.command.serverinfo.joinedAt"]}", "${timeJoined.humanize(locale)} ($joinedAtDiff)", true)
+		embed.addField("👥 ${context.locale["commands.command.serverinfo.members"]} ($memberCount)", "", true) // Membros da Guild
 
 		context.sendMessage(context.getAsMention(true), embed.build()) // phew, agora finalmente poderemos enviar o embed!
 	}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/UserInfoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/discord/UserInfoCommand.kt
@@ -25,7 +25,7 @@ import net.perfectdreams.loritta.platform.discord.utils.UserFlagBadgeEmotes.getB
 import net.perfectdreams.loritta.utils.Emotes
 
 class UserInfoCommand : AbstractCommand("userinfo", listOf("memberinfo"), CommandCategory.DISCORD) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.discord.userinfo.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.userinfo.description")
 
 	override fun canUseInPrivateChannel(): Boolean {
 		return false
@@ -38,7 +38,7 @@ class UserInfoCommand : AbstractCommand("userinfo", listOf("memberinfo"), Comman
 			if (context.args.getOrNull(0) != null) {
 				context.reply(
                         LorittaReply(
-                                locale["commands.discord.userinfo.unknownUser", context.args[0].stripCodeMarks()],
+                                locale["commands.command.userinfo.unknownUser", context.args[0].stripCodeMarks()],
                                 Constants.ERROR
                         )
 				)
@@ -85,7 +85,7 @@ class UserInfoCommand : AbstractCommand("userinfo", listOf("memberinfo"), Comman
 			}
 
 			if (addBadgesToField)
-				addField("\uD83D\uDCDB ${context.locale["commands.discord.userinfo.badges"]}", getBadges(user).joinToString(""), true)
+				addField("\uD83D\uDCDB ${context.locale["commands.command.userinfo.badges"]}", getBadges(user).joinToString(""), true)
 
 			setTitle(title)
 
@@ -104,23 +104,23 @@ class UserInfoCommand : AbstractCommand("userinfo", listOf("memberinfo"), Comman
 		val embed = getEmbedBase(context, user, member)
 
 		embed.apply {
-			addField("\uD83D\uDD16 ${context.locale["commands.discord.userinfo.discordTag"]}", "`${user.name}#${user.discriminator}`", true)
-			addField("\uD83D\uDCBB ${context.locale["commands.discord.userinfo.discordId"]}", "`${user.id}`", true)
+			addField("\uD83D\uDD16 ${context.locale["commands.command.userinfo.discordTag"]}", "`${user.name}#${user.discriminator}`", true)
+			addField("\uD83D\uDCBB ${context.locale["commands.command.userinfo.discordId"]}", "`${user.id}`", true)
 
 			val accountCreatedDiff = DateUtils.formatDateDiff(user.timeCreated.toInstant().toEpochMilli(), context.locale)
-			addField("\uD83D\uDCC5 ${context.locale["commands.discord.userinfo.accountCreated"]}", accountCreatedDiff, true)
+			addField("\uD83D\uDCC5 ${context.locale["commands.command.userinfo.accountCreated"]}", accountCreatedDiff, true)
 			if (member != null) {
 				val accountJoinedDiff = DateUtils.formatDateDiff(member.timeJoined.toInstant().toEpochMilli(), context.locale)
-				addField("\uD83C\uDF1F ${context.locale["commands.discord.userinfo.accountJoined"]}", accountJoinedDiff, true)
+				addField("\uD83C\uDF1F ${context.locale["commands.command.userinfo.accountJoined"]}", accountJoinedDiff, true)
 
 				if (member.timeBoosted != null) {
 					val timeBoosted = DateUtils.formatDateDiff(member.timeBoosted!!.toInstant().toEpochMilli(), context.locale)
-					addField("${Emotes.LORI_NITRO_BOOST} ${context.locale["commands.discord.userinfo.boostingSince"]}", timeBoosted, true)
+					addField("${Emotes.LORI_NITRO_BOOST} ${context.locale["commands.command.userinfo.boostingSince"]}", timeBoosted, true)
 				}
 			}
 
 			if (context.message.channel.idLong == 358774895850815488L || context.message.channel.idLong == 547119872568459284L) {
-				var sharedServersFieldTitle = context.locale["commands.discord.userinfo.sharedServers"]
+				var sharedServersFieldTitle = context.locale["commands.command.userinfo.sharedServers"]
 				var servers: String?
 
 				val sharedServersResults = lorittaShards.queryMutualGuildsInAllLorittaClusters(user.id)
@@ -156,7 +156,7 @@ class UserInfoCommand : AbstractCommand("userinfo", listOf("memberinfo"), Comman
 		embed.apply {
 			if (member != null) {
 				val roles = member.roles.joinToString(separator = ", ", transform = { "`${it.name}`" })
-				addField("\uD83D\uDCBC " + context.locale["commands.discord.userinfo.roles"] + " (${member.roles.size})", if (roles.isNotEmpty()) roles.substringIfNeeded(0 until 1024) else context.locale["commands.discord.userinfo.noRoles"] + " \uD83D\uDE2D", true)
+				addField("\uD83D\uDCBC " + context.locale["commands.command.userinfo.roles"] + " (${member.roles.size})", if (roles.isNotEmpty()) roles.substringIfNeeded(0 until 1024) else context.locale["commands.command.userinfo.noRoles"] + " \uD83D\uDE2D", true)
 
 				val permissions = member.getPermissions(context.message.textChannel).joinToString(", ", transform = { "`${it.localized(context.locale)}`" })
 				addField("\uD83D\uDEE1 Permissões", permissions, false)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/DailyCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/DailyCommand.kt
@@ -12,7 +12,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
 class DailyCommand : AbstractCommand("daily", listOf("diário", "bolsafamilia", "bolsafamília"), CommandCategory.ECONOMY) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.economy.daily.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.daily.description")
 
 	override suspend fun run(context: CommandContext, locale: BaseLocale) {
 		// 1. Pegue quando o daily foi pego da última vez
@@ -23,11 +23,11 @@ class DailyCommand : AbstractCommand("daily", listOf("diário", "bolsafamilia", 
 		if (!canGetDaily) {
 			context.reply(
                     LorittaReply(
-                            locale["commands.economy.daily.pleaseWait", DateUtils.formatDateDiff(tomorrow, locale)],
+                            locale["commands.command.daily.pleaseWait", DateUtils.formatDateDiff(tomorrow, locale)],
                             Constants.ERROR
                     ),
                     LorittaReply(
-                            locale["commands.economy.daily.pleaseWaitBuySonhos", "<${loritta.instanceConfig.loritta.website.url}user/@me/dashboard/bundles>"],
+                            locale["commands.command.daily.pleaseWaitBuySonhos", "<${loritta.instanceConfig.loritta.website.url}user/@me/dashboard/bundles>"],
                             "\uD83D\uDCB3"
                     )
 			)
@@ -36,11 +36,11 @@ class DailyCommand : AbstractCommand("daily", listOf("diário", "bolsafamilia", 
 
 		context.reply(
                 LorittaReply(
-                        locale["commands.economy.daily.dailyLink", "${loritta.instanceConfig.loritta.website.url}daily"],
+                        locale["commands.command.daily.dailyLink", "${loritta.instanceConfig.loritta.website.url}daily"],
                         Emotes.LORI_RICH
                 ),
                 LorittaReply(
-                        locale["commands.economy.daily.dailyLinkBuySonhos", "<${loritta.instanceConfig.loritta.website.url}user/@me/dashboard/bundles>"],
+                        locale["commands.command.daily.dailyLinkBuySonhos", "<${loritta.instanceConfig.loritta.website.url}user/@me/dashboard/bundles>"],
                         "\uD83D\uDCB3"
                 )
 		)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/LoraffleCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/LoraffleCommand.kt
@@ -30,8 +30,8 @@ class LoraffleCommand : AbstractCommand("loraffle", listOf("rifa", "raffle", "lo
 		const val MAX_TICKETS_BY_USER_PER_ROUND = 100_000
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.economy.raffle.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.economy.raffle.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.raffle.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.raffle.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		val arg0 = context.args.getOrNull(0)
@@ -121,7 +121,7 @@ class LoraffleCommand : AbstractCommand("loraffle", listOf("rifa", "raffle", "lo
 			if (status == BuyRaffleTicketStatus.NOT_ENOUGH_MONEY) {
 				context.reply(
                         LorittaReply(
-                                context.locale["commands.economy.raffle.notEnoughMoney", json["canOnlyPay"].int, quantity, if (quantity == 1) "" else "s"],
+                                context.locale["commands.command.raffle.notEnoughMoney", json["canOnlyPay"].int, quantity, if (quantity == 1) "" else "s"],
                                 Constants.ERROR
                         )
 				)
@@ -130,11 +130,11 @@ class LoraffleCommand : AbstractCommand("loraffle", listOf("rifa", "raffle", "lo
 
 			context.reply(
                     LorittaReply(
-                            context.locale["commands.economy.raffle.youBoughtAnTicket", quantity, if (quantity == 1) "" else "s", quantity.toLong() * 250],
+                            context.locale["commands.command.raffle.youBoughtAnTicket", quantity, if (quantity == 1) "" else "s", quantity.toLong() * 250],
                             "\uD83C\uDFAB"
                     ),
                     LorittaReply(
-                            context.locale["commands.economy.raffle.wantMoreChances", context.config.commandPrefix],
+                            context.locale["commands.command.raffle.wantMoreChances", context.config.commandPrefix],
                             mentionUser = false
                     )
 			)
@@ -183,32 +183,32 @@ class LoraffleCommand : AbstractCommand("loraffle", listOf("rifa", "raffle", "lo
                         "<:loritta:331179879582269451>"
                 ),
                 LorittaReply(
-                        context.locale["commands.economy.raffle.currentPrize", (currentTickets * 250).toString()],
+                        context.locale["commands.command.raffle.currentPrize", (currentTickets * 250).toString()],
                         "<:starstruck:540988091117076481>",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        context.locale["commands.economy.raffle.boughtTickets", currentTickets],
+                        context.locale["commands.command.raffle.boughtTickets", currentTickets],
                         "\uD83C\uDFAB",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        context.locale["commands.economy.raffle.usersParticipating", usersParticipating],
+                        context.locale["commands.command.raffle.usersParticipating", usersParticipating],
                         "\uD83D\uDC65",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        context.locale["commands.economy.raffle.lastWinner", "$nameAndDiscriminator (${lastWinner?.id})", lastWinnerPrize],
+                        context.locale["commands.command.raffle.lastWinner", "$nameAndDiscriminator (${lastWinner?.id})", lastWinnerPrize],
                         "\uD83D\uDE0E",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        context.locale["commands.economy.raffle.resultsIn", DateUtils.formatDateDiff(Calendar.getInstance(), cal, locale)],
+                        context.locale["commands.command.raffle.resultsIn", DateUtils.formatDateDiff(Calendar.getInstance(), cal, locale)],
                         prefix = "\uD83D\uDD52",
                         mentionUser = false
                 ),
                 LorittaReply(
-                        context.locale["commands.economy.raffle.buyAnTicketFor", context.config.commandPrefix],
+                        context.locale["commands.command.raffle.buyAnTicketFor", context.config.commandPrefix],
                         prefix = "\uD83D\uDCB5",
                         mentionUser = false
                 )

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/PagarCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/PagarCommand.kt
@@ -34,8 +34,8 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 		private val mutex = Mutex()
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.economy.pay.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.economy.pay.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.pay.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.pay.examples")
 
 	// TODO: Fix Usage
 
@@ -135,7 +135,7 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 			if (howMuch.toBigDecimal() > balanceQuantity) {
 				context.reply(
 						LorittaReply(
-								locale["commands.economy.pay.insufficientFunds", if (economySource == "global") locale["economy.currency.name.plural"] else economyConfig?.economyNamePlural],
+								locale["commands.command.pay.insufficientFunds", if (economySource == "global") locale["economy.currency.name.plural"] else economyConfig?.economyNamePlural],
 								Constants.ERROR
 						)
 				)
@@ -171,7 +171,7 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 						// reject the sonhos
 						context.reply(
 								LorittaReply(
-										context.locale["commands.economy.pay.doYouThinkImPoor"],
+										context.locale["commands.command.pay.doYouThinkImPoor"],
 										Emotes.LORI_BAN_HAMMER
 								)
 						)
@@ -180,23 +180,23 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 				}
 
 				val quirkyMessage = when {
-					howMuch >= 500_000 -> " ${context.locale.getList("commands.economy.pay.randomQuirkyRichMessages").random()}"
-					tellUserLorittaIsGrateful -> " ${context.locale.getList("commands.economy.pay.randomLorittaIsGratefulMessages").random()}"
+					howMuch >= 500_000 -> " ${context.locale.getList("commands.command.pay.randomQuirkyRichMessages").random()}"
+					tellUserLorittaIsGrateful -> " ${context.locale.getList("commands.command.pay.randomLorittaIsGratefulMessages").random()}"
 					else -> ""
 				}
 
 				val message = context.reply(
 						LorittaReply(
-								context.locale["commands.economy.pay.youAreGoingToTransfer", howMuch, user.asMention, quirkyMessage],
+								context.locale["commands.command.pay.youAreGoingToTransfer", howMuch, user.asMention, quirkyMessage],
 								Emotes.LORI_RICH
 						),
 						LorittaReply(
-								context.locale["commands.economy.pay.clickToAcceptTheTransaction", user.asMention, "✅"],
+								context.locale["commands.command.pay.clickToAcceptTheTransaction", user.asMention, "✅"],
 								"🤝",
 								mentionUser = false
 						),
 						LorittaReply(
-								context.locale["commands.economy.pay.sellDisallowedWarning", "${loritta.instanceConfig.loritta.website.url}guidelines"],
+								context.locale["commands.command.pay.sellDisallowedWarning", "${loritta.instanceConfig.loritta.website.url}guidelines"],
 								Emotes.LORI_BAN_HAMMER,
 								mentionUser = false
 						)
@@ -244,7 +244,7 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 										val finalMoney = result["finalMoney"].double
 										context.reply(
 												LorittaReply(
-														locale["commands.economy.pay.transitionComplete", user.asMention, finalMoney, if (finalMoney == 1.0) {
+														locale["commands.command.pay.transitionComplete", user.asMention, finalMoney, if (finalMoney == 1.0) {
 															locale["economy.currency.name.singular"]
 														} else {
 															locale["economy.currency.name.plural"]
@@ -275,7 +275,7 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 
 				context.reply(
 						LorittaReply(
-								locale["commands.economy.pay.transitionComplete", user.asMention, howMuch, if (howMuch.toLong() == 1L) {
+								locale["commands.command.pay.transitionComplete", user.asMention, howMuch, if (howMuch.toLong() == 1L) {
 									economyConfig?.economyName
 								} else {
 									economyConfig?.economyNamePlural
@@ -311,7 +311,7 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 		if (epochMillis + (Constants.ONE_WEEK_IN_MILLISECONDS * 2) > System.currentTimeMillis()) { // 14 dias
 			context.reply(
 					LorittaReply(
-							context.locale["commands.economy.pay.selfAccountIsTooNew", 14] + " ${Emotes.LORI_CRYING}",
+							context.locale["commands.command.pay.selfAccountIsTooNew", 14] + " ${Emotes.LORI_CRYING}",
 							Constants.ERROR
 					)
 			)
@@ -326,7 +326,7 @@ class PagarCommand : AbstractCommand("pay", listOf("pagar"), CommandCategory.ECO
 		if (epochMillis + Constants.ONE_WEEK_IN_MILLISECONDS > System.currentTimeMillis()) { // 7 dias
 			context.reply(
 					LorittaReply(
-							context.locale["commands.economy.pay.otherAccountIsTooNew", target.asMention, 7] + " ${Emotes.LORI_CRYING}",
+							context.locale["commands.command.pay.otherAccountIsTooNew", target.asMention, 7] + " ${Emotes.LORI_CRYING}",
 							Constants.ERROR
 					)
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/SonhosCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/SonhosCommand.kt
@@ -16,8 +16,8 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import java.math.BigDecimal
 
 class SonhosCommand : AbstractCommand("sonhos", listOf("atm", "bal", "balance"), category = CommandCategory.ECONOMY) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.economy.sonhos.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.economy.sonhos.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.sonhos.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.sonhos.examples")
 
 	override suspend fun run(context: CommandContext, locale: BaseLocale) {
 		val retrieveDreamsFromUser = context.getUserAt(0) ?: context.userHandle
@@ -45,10 +45,10 @@ class SonhosCommand : AbstractCommand("sonhos", listOf("atm", "bal", "balance"),
 
 			val youHaveReply = LorittaReply(
                     context.locale[
-                            "commands.economy.sonhos.youHaveSonhos",
+                            "commands.command.sonhos.youHaveSonhos",
                             userSonhos,
                             context.locale[
-                                    "commands.economy.sonhos.sonhos.${if (userSonhos == 1L) "one" else "multiple"}"
+                                    "commands.command.sonhos.sonhos.${if (userSonhos == 1L) "one" else "multiple"}"
                             ],
                             if (userSonhos > 0) {
                                 val globalEconomyPosition = loritta.newSuspendedTransaction {
@@ -56,10 +56,10 @@ class SonhosCommand : AbstractCommand("sonhos", listOf("atm", "bal", "balance"),
                                 }
 
                                 context.locale[
-                                        "commands.economy.sonhos.currentRankPosition",
+                                        "commands.command.sonhos.currentRankPosition",
                                         globalEconomyPosition,
                                         context.locale[
-                                                "commands.economy.sonhos.sonhosRankingCommand",
+                                                "commands.command.sonhos.sonhosRankingCommand",
                                                 context.config.commandPrefix
                                         ]
                                 ]
@@ -76,7 +76,7 @@ class SonhosCommand : AbstractCommand("sonhos", listOf("atm", "bal", "balance"),
 						false,
 						youHaveReply,
                         LorittaReply(
-                                locale["commands.economy.sonhos.youHaveSonhos", localProfile.money, if (localProfile.money == BigDecimal.ONE) {
+                                locale["commands.command.sonhos.youHaveSonhos", localProfile.money, if (localProfile.money == BigDecimal.ONE) {
                                     economyConfig.economyName
                                 } else {
                                     economyConfig.economyNamePlural
@@ -96,22 +96,22 @@ class SonhosCommand : AbstractCommand("sonhos", listOf("atm", "bal", "balance"),
 
 			val someoneHasReply = LorittaReply(
                     context.locale[
-                            "commands.economy.sonhos.userHasSonhos",
+                            "commands.command.sonhos.userHasSonhos",
                             retrieveDreamsFromUser.asMention,
                             userSonhos,
                             context.locale[
-                                    "commands.economy.sonhos.sonhos.${if (userSonhos == 1L) "one" else "multiple"}"
+                                    "commands.command.sonhos.sonhos.${if (userSonhos == 1L) "one" else "multiple"}"
                             ],
                             if (userSonhos > 0) {
                                 val globalEconomyPosition = loritta.newSuspendedTransaction {
                                     Profiles.select { Profiles.money greaterEq userSonhos }.count()
                                 }
                                 context.locale[
-                                        "commands.economy.sonhos.userCurrentRankPosition",
+                                        "commands.command.sonhos.userCurrentRankPosition",
                                         retrieveDreamsFromUser.asMention,
                                         globalEconomyPosition,
                                         context.locale[
-                                                "commands.economy.sonhos.sonhosRankingCommand",
+                                                "commands.command.sonhos.sonhosRankingCommand",
                                                 context.config.commandPrefix
                                         ]
                                 ]
@@ -128,7 +128,7 @@ class SonhosCommand : AbstractCommand("sonhos", listOf("atm", "bal", "balance"),
 						false,
 						someoneHasReply,
                         LorittaReply(
-                                locale["commands.economy.sonhos.userHasSonhos", retrieveDreamsFromUser.asMention, localProfile.money, if (localProfile.money == BigDecimal.ONE) {
+                                locale["commands.command.sonhos.userHasSonhos", retrieveDreamsFromUser.asMention, localProfile.money, if (localProfile.money == BigDecimal.ONE) {
                                     economyConfig.economyName
                                 } else {
                                     economyConfig.economyNamePlural

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/AvaliarWaifuCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/AvaliarWaifuCommand.kt
@@ -12,7 +12,7 @@ import java.util.*
 
 class AvaliarWaifuCommand : AbstractCommand("ratewaifu", listOf("avaliarwaifu", "ratemywaifu", "ratewaifu", "avaliarminhawaifu", "notawaifu"), CommandCategory.FUN) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.fun.ratewaifu"
+		private const val LOCALE_PREFIX = "commands.command.ratewaifu"
 	}
 
 	override fun getDescriptionKey() = LocaleKeyData("$LOCALE_PREFIX.description")

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/BemBoladaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/BemBoladaCommand.kt
@@ -11,7 +11,7 @@ import com.mrpowergamerbr.loritta.utils.loritta
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class BemBoladaCommand : AbstractCommand("bembolada", listOf("kenji"), CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.bembolada.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.bembolada.description")
 
 	override fun hasCommandFeedback(): Boolean {
 		return false

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/CaraCoroaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/CaraCoroaCommand.kt
@@ -10,10 +10,10 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class CaraCoroaCommand : AbstractCommand("coinflip", listOf("girarmoeda", "flipcoin", "caracoroa"), CommandCategory.FUN) {
 	companion object {
-		const val LOCALE_PREFIX = "commands.fun.flipcoin"
+		const val LOCALE_PREFIX = "commands.command.flipcoin"
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.flipcoin.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.flipcoin.description")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		val isTails = Loritta.RANDOM.nextBoolean()

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/FaustaoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/FaustaoCommand.kt
@@ -46,7 +46,7 @@ class FaustaoCommand : AbstractCommand("faustão", listOf("faustao"), CommandCat
 			"http://i.imgur.com/rVmgwZC.png",
 			"http://i.imgur.com/z7Ec5I3.png")
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.faustao.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.faustao.description")
 
 	override fun hasCommandFeedback(): Boolean {
 		return false

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/MagicBallCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/MagicBallCommand.kt
@@ -12,8 +12,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.arguments
 
 class MagicBallCommand : AbstractCommand("vieirinha", listOf("8ball", "magicball", "eightball"), CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.vieirinha.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.fun.vieirinha.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.vieirinha.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.vieirinha.examples")
 
 	override fun getUsage(): CommandArguments {
 		return arguments {
@@ -37,7 +37,7 @@ class MagicBallCommand : AbstractCommand("vieirinha", listOf("8ball", "magicball
 
 			context.sendMessage(temmie, WebhookMessageBuilder()
 					.setUsername("Vieirinha")
-					.setContent(context.getAsMention(true) + locale.getList("commands.fun.vieirinha.responses").random())
+					.setContent(context.getAsMention(true) + locale.getList("commands.command.vieirinha.responses").random())
 					.setAvatarUrl("http://i.imgur.com/rRtHdti.png")
 					.build())
 		} else {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/PedraPapelTesouraCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/PedraPapelTesouraCommand.kt
@@ -11,8 +11,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class PedraPapelTesouraCommand : AbstractCommand("jankenpon", listOf("pedrapapeltesoura", "ppt"), CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.rockpaperscissors.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.fun.rockpaperscissors.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.rockpaperscissors.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.rockpaperscissors.examples")
 
 	// TODO: Fix Usage
 	// TODO: Fix Detailed Usage
@@ -30,13 +30,13 @@ class PedraPapelTesouraCommand : AbstractCommand("jankenpon", listOf("pedrapapel
 
 				var fancy: String? = null
 				if (status == JankenponStatus.WIN) {
-					fancy = "**${context.locale["commands.fun.rockpaperscissors.win"]} \uD83D\uDE0A**"
+					fancy = "**${context.locale["commands.command.rockpaperscissors.win"]} \uD83D\uDE0A**"
 				}
 				if (status == JankenponStatus.LOSE) {
-					fancy = "**${context.locale["commands.fun.rockpaperscissors.lose"]} \uD83D\uDE42**"
+					fancy = "**${context.locale["commands.command.rockpaperscissors.lose"]} \uD83D\uDE42**"
 				}
 				if (status == JankenponStatus.DRAW) {
-					fancy = "**${context.locale["commands.fun.rockpaperscissors.draw"]} \uD83D\uDE0A**"
+					fancy = "**${context.locale["commands.command.rockpaperscissors.draw"]} \uD83D\uDE0A**"
 				}
 				if (fancy == null) {
 					return
@@ -47,22 +47,22 @@ class PedraPapelTesouraCommand : AbstractCommand("jankenpon", listOf("pedrapapel
 					JankenponStatus.LOSE -> "\uD83C\uDFF4"
 				}
 				context.reply(
-                        LorittaReply(message = context.locale["commands.fun.rockpaperscissors.chosen", janken.emoji, opponent.emoji], prefix = prefix),
+                        LorittaReply(message = context.locale["commands.command.rockpaperscissors.chosen", janken.emoji, opponent.emoji], prefix = prefix),
                         LorittaReply(message = fancy, mentionUser = false)
 				)
 			} else {
 				if (playerValue.equals("jesus", ignoreCase = true)) {
-					val fancy = "**${context.locale["commands.fun.rockpaperscissors.maybeDraw"]} 🤔 🤷**"
-					val jesus = "🙇 *${context.locale["commands.fun.rockpaperscissors.jesusChrist"]}* 🙇"
+					val fancy = "**${context.locale["commands.command.rockpaperscissors.maybeDraw"]} 🤔 🤷**"
+					val jesus = "🙇 *${context.locale["commands.command.rockpaperscissors.jesusChrist"]}* 🙇"
 					context.reply(
-                            LorittaReply(message = context.locale["commands.fun.rockpaperscissors.chosen", jesus, jesus], prefix = "\uD83C\uDFF3"),
+                            LorittaReply(message = context.locale["commands.command.rockpaperscissors.chosen", jesus, jesus], prefix = "\uD83C\uDFF3"),
                             LorittaReply(message = fancy, mentionUser = false)
 					)
 				} else {
-					val fancy = "**${context.locale["commands.fun.rockpaperscissors.invalidChoice"]} \uD83D\uDE09**"
-					val jesus = "🙇 *${context.locale["commands.fun.rockpaperscissors.jesusChrist"]}* 🙇"
+					val fancy = "**${context.locale["commands.command.rockpaperscissors.invalidChoice"]} \uD83D\uDE09**"
+					val jesus = "🙇 *${context.locale["commands.command.rockpaperscissors.jesusChrist"]}* 🙇"
 					context.reply(
-                            LorittaReply(message = context.locale["commands.fun.rockpaperscissors.chosen", "\uD83D\uDCA9", jesus], prefix = "\uD83C\uDFF4"),
+                            LorittaReply(message = context.locale["commands.command.rockpaperscissors.chosen", "\uD83D\uDCA9", jesus], prefix = "\uD83C\uDFF4"),
                             LorittaReply(message = fancy, mentionUser = false)
 					)
 				}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/QualidadeCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/QualidadeCommand.kt
@@ -9,8 +9,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class QualidadeCommand : AbstractCommand("qualidade", category = CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.quality.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.fun.quality.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.quality.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.quality.examples")
 	// TODO: Fix Usage
 	// TODO: Fix Detailed Usage
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/RollCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/RollCommand.kt
@@ -20,7 +20,7 @@ import net.perfectdreams.loritta.utils.math.MathUtils
 
 class RollCommand : AbstractCommand("roll", listOf("rolar", "dice", "dado"), CommandCategory.FUN) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.fun.roll"
+		private const val LOCALE_PREFIX = "commands.command.roll"
 	}
 
 	override fun getDescriptionKey() = LocaleKeyData("$LOCALE_PREFIX.description")
@@ -35,7 +35,7 @@ class RollCommand : AbstractCommand("roll", listOf("rolar", "dice", "dado"), Com
 		}
 	}
 
-	override fun getExamplesKey() = LocaleKeyData("commands.fun.roll.examples")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.roll.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		var quantity = 1L

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/ShipCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/ShipCommand.kt
@@ -33,8 +33,8 @@ import java.io.File
 import java.util.*
 
 class ShipCommand : AbstractCommand("ship", listOf("shippar"), CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.ship.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.fun.ship.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.ship.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.ship.examples")
 
 	override fun getUsage() = arguments {
 		argument(ArgumentType.USER) {}
@@ -74,7 +74,7 @@ class ShipCommand : AbstractCommand("ship", listOf("shippar"), CommandCategory.F
 		}
 
 		if (user1Name != null && user2Name != null && user1Name.isNotEmpty() && user2Name.isNotEmpty()) {
-			var texto = context.getAsMention(true) + "\n💖 **${context.locale["commands.fun.ship.newCouple"]}** 💖\n"
+			var texto = context.getAsMention(true) + "\n💖 **${context.locale["commands.command.ship.newCouple"]}** 💖\n"
 
 			texto += "`${user1Name.stripCodeMarks()}`\n`${user2Name.stripCodeMarks()}`\n"
 
@@ -132,7 +132,7 @@ class ShipCommand : AbstractCommand("ship", listOf("shippar"), CommandCategory.F
 			if (Loritta.RANDOM.nextInt(0, 50) == 9 && context.lorittaUser.profile.money >= 3000) {
 				context.reply(
 						LorittaReply(
-								context.locale["commands.fun.ship.bribeLove", "${loritta.instanceConfig.loritta.website.url}user/@me/dashboard/ship-effects"]
+								context.locale["commands.command.ship.bribeLove", "${loritta.instanceConfig.loritta.website.url}user/@me/dashboard/ship-effects"]
 						)
 				)
 			}
@@ -144,16 +144,16 @@ class ShipCommand : AbstractCommand("ship", listOf("shippar"), CommandCategory.F
 			}
 
 			val messages: List<String> = when {
-				percentage >= 90 -> context.locale.getList("commands.fun.ship.value90")
-				percentage >= 80 -> context.locale.getList("commands.fun.ship.value80")
-				percentage >= 70 -> context.locale.getList("commands.fun.ship.value70")
-				percentage >= 60 -> context.locale.getList("commands.fun.ship.value60")
-				percentage >= 50 -> context.locale.getList("commands.fun.ship.value50")
-				percentage >= 40 -> context.locale.getList("commands.fun.ship.value40")
-				percentage >= 30 -> context.locale.getList("commands.fun.ship.value30")
-				percentage >= 20 -> context.locale.getList("commands.fun.ship.value20")
-				percentage >= 10 -> context.locale.getList("commands.fun.ship.value10")
-				percentage >= 0  -> context.locale.getList("commands.fun.ship.value0")
+				percentage >= 90 -> context.locale.getList("commands.command.ship.value90")
+				percentage >= 80 -> context.locale.getList("commands.command.ship.value80")
+				percentage >= 70 -> context.locale.getList("commands.command.ship.value70")
+				percentage >= 60 -> context.locale.getList("commands.command.ship.value60")
+				percentage >= 50 -> context.locale.getList("commands.command.ship.value50")
+				percentage >= 40 -> context.locale.getList("commands.command.ship.value40")
+				percentage >= 30 -> context.locale.getList("commands.command.ship.value30")
+				percentage >= 20 -> context.locale.getList("commands.command.ship.value20")
+				percentage >= 10 -> context.locale.getList("commands.command.ship.value10")
+				percentage >= 0  -> context.locale.getList("commands.command.ship.value0")
 				else -> {
 					throw RuntimeException("Can't find ship value for percentage $percentage")
 				}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/TioDoPaveCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/TioDoPaveCommand.kt
@@ -9,7 +9,7 @@ import com.mrpowergamerbr.loritta.utils.locale.LocaleKeyData
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class TioDoPaveCommand : AbstractCommand("tiodopave", listOf("piada"), CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.tiodopave.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.tiodopave.description")
 
 	override fun hasCommandFeedback(): Boolean {
 		return false

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/TwitchCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/TwitchCommand.kt
@@ -12,8 +12,8 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import java.awt.Color
 
 class TwitchCommand : AbstractCommand("twitch", category = CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.twitch.description")
-	override fun getExamplesKey()  = LocaleKeyData("commands.fun.twitch.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.twitch.description")
+	override fun getExamplesKey()  = LocaleKeyData("commands.command.twitch.examples")
 
 	override fun canUseInPrivateChannel(): Boolean {
 		return false
@@ -26,7 +26,7 @@ class TwitchCommand : AbstractCommand("twitch", category = CommandCategory.FUN) 
 			if (!Constants.TWITCH_USERNAME_PATTERN.matcher(query).matches()) {
 				context.reply(
                         LorittaReply(
-                                context.locale["commands.fun.twitch.couldntFind", query],
+                                context.locale["commands.command.twitch.couldntFind", query],
                                 Constants.ERROR
                         )
 				)
@@ -38,7 +38,7 @@ class TwitchCommand : AbstractCommand("twitch", category = CommandCategory.FUN) 
 			if (payload == null) {
 				context.reply(
                         LorittaReply(
-								context.locale["commands.fun.twitch.couldntFind", query],
+								context.locale["commands.command.twitch.couldntFind", query],
                                 Constants.ERROR
                         )
 				)
@@ -62,7 +62,7 @@ class TwitchCommand : AbstractCommand("twitch", category = CommandCategory.FUN) 
 				if (offlineImageUrl.isNotEmpty()) {
 					setImage(offlineImageUrl)
 				}
-				addField("\uD83D\uDCFA ${context.locale["commands.fun.twitch.views"]}", viewCount.toString(), true)
+				addField("\uD83D\uDCFA ${context.locale["commands.command.twitch.views"]}", viewCount.toString(), true)
 			}
 
 			context.sendMessage(context.getAsMention(true), embed.build())

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/VaporQualidadeCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/VaporQualidadeCommand.kt
@@ -10,8 +10,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class VaporQualidadeCommand : AbstractCommand("vaporqualidade", category = CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.vaporquality.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.fun.vaporquality.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.vaporquality.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.vaporquality.examples")
 
 	// TODO: Fix Usage
 	// TODO: Fix Detailed Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/VaporondaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/VaporondaCommand.kt
@@ -10,8 +10,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class VaporondaCommand : AbstractCommand("vaporonda", listOf("vaporwave"), category = CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.vaporwave.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.fun.vaporwave.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.vaporwave.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.vaporwave.examples")
 
 	// TODO: Fix Usage
 	// TODO: Fix Detailed Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/VemDeZapCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/fun/VemDeZapCommand.kt
@@ -15,8 +15,8 @@ import net.perfectdreams.loritta.api.commands.arguments
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class VemDeZapCommand : AbstractCommand("vemdezap", category = CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.fun.vemdezap.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.fun.vemdezap.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.vemdezap.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.vemdezap.examples")
 
 	override fun getUsage(): CommandArguments {
 		return arguments {
@@ -356,31 +356,31 @@ class VemDeZapCommand : AbstractCommand("vemdezap", category = CommandCategory.F
 
 			val message = context.reply(
                     LorittaReply(
-                            locale["commands.fun.vemdezap.whatIsTheMood"],
+                            locale["commands.command.vemdezap.whatIsTheMood"],
                             "\uD83E\uDD14"
                     ),
                     LorittaReply(
-                            locale["commands.fun.vemdezap.moodHappy"],
+                            locale["commands.command.vemdezap.moodHappy"],
                             "\uD83D\uDE0A",
                             mentionUser = false
                     ),
                     LorittaReply(
-                            locale["commands.fun.vemdezap.moodAngry"],
+                            locale["commands.command.vemdezap.moodAngry"],
                             "\uD83D\uDE21",
                             mentionUser = false
                     ),
                     LorittaReply(
-                            locale["commands.fun.vemdezap.moodSassy"],
+                            locale["commands.command.vemdezap.moodSassy"],
                             "\uD83D\uDE0F",
                             mentionUser = false
                     ),
                     LorittaReply(
-                            locale["commands.fun.vemdezap.moodSad"],
+                            locale["commands.command.vemdezap.moodSad"],
                             "\uD83D\uDE22",
                             mentionUser = false
                     ),
                     LorittaReply(
-                            locale["commands.fun.vemdezap.moodSick"],
+                            locale["commands.command.vemdezap.moodSick"],
                             "\uD83E\uDD12",
                             mentionUser = false
                     )
@@ -400,31 +400,31 @@ class VemDeZapCommand : AbstractCommand("vemdezap", category = CommandCategory.F
 
 				val levelMessage = context.reply(
                         LorittaReply(
-                                locale["commands.fun.vemdezap.whatIsTheLevel"],
+                                locale["commands.command.vemdezap.whatIsTheLevel"],
                                 "\uD83E\uDD14"
                         ),
                         LorittaReply(
-                                locale["commands.fun.vemdezap.level1"],
+                                locale["commands.command.vemdezap.level1"],
                                 "1⃣",
                                 mentionUser = false
                         ),
                         LorittaReply(
-                                locale["commands.fun.vemdezap.level2"],
+                                locale["commands.command.vemdezap.level2"],
                                 "2⃣",
                                 mentionUser = false
                         ),
                         LorittaReply(
-                                locale["commands.fun.vemdezap.level3"],
+                                locale["commands.command.vemdezap.level3"],
                                 "3⃣",
                                 mentionUser = false
                         ),
                         LorittaReply(
-                                locale["commands.fun.vemdezap.level4"],
+                                locale["commands.command.vemdezap.level4"],
                                 "4⃣",
                                 mentionUser = false
                         ),
                         LorittaReply(
-                                locale["commands.fun.vemdezap.level5"],
+                                locale["commands.command.vemdezap.level5"],
                                 "5⃣",
                                 mentionUser = false
                         )

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/AmigosCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/AmigosCommand.kt
@@ -23,8 +23,8 @@ class AmigosCommand : AbstractCommand("friends", listOf("amigos", "meusamigos", 
 		val TEMPLATE by lazy { ImageIO.read(File(Constants.ASSETS_FOLDER, "thx.png")) }
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.friends.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.lava.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.friends.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.lava.examples")
 
 	override fun getUsage() = arguments {
 		repeat(9) {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/AmizadeCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/AmizadeCommand.kt
@@ -25,7 +25,7 @@ class AmizadeCommand : AbstractCommand("friendship", listOf("amizade"), CommandC
 		val TEMPLATE_OVERLAY by lazy { ImageIO.read(File(Constants.ASSETS_FOLDER, "amizade_overlay.png")) }
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.friendship.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.friendship.description")
 	// TODO: Needs to be two users
 	// override fun getExamplesKey() = Command.TWO_IMAGES_EXAMPLES_KEY
 
@@ -62,7 +62,7 @@ class AmizadeCommand : AbstractCommand("friendship", listOf("amizade"), CommandC
 			graphics.font = font
 			var fontMetrics = graphics.getFontMetrics(font)
 
-			val friendshipEnded = locale["commands.images.friendship.friendWith", user.name]
+			val friendshipEnded = locale["commands.command.friendship.friendWith", user.name]
 			var gp = GradientPaint(
 					0.0f, 0.0f,
                     Color(202, 72, 15),
@@ -76,7 +76,7 @@ class AmizadeCommand : AbstractCommand("friendship", listOf("amizade"), CommandC
 			font = font.deriveFont(30F)
 			graphics.font = font
 
-			ImageUtils.drawCenteredStringOutlined(graphics, locale["commands.images.friendship.ended"], Rectangle(0, 30, 400, 40), font)
+			ImageUtils.drawCenteredStringOutlined(graphics, locale["commands.command.friendship.ended"], Rectangle(0, 30, 400, 40), font)
 
 			font = font.deriveFont(24F)
 			graphics.font = font
@@ -88,10 +88,10 @@ class AmizadeCommand : AbstractCommand("friendship", listOf("amizade"), CommandC
 					Color(103, 216, 11))
 			graphics.paint = gp
 			// graphics.fillRect(0, 0, 400, 300); // debugging
-			ImageUtils.drawCenteredStringOutlined(graphics, "${locale["commands.images.friendship.now"]} " + user2.name, Rectangle(0, 100, 400, 110), font)
-			ImageUtils.drawCenteredStringOutlined(graphics, locale["commands.images.friendship.isMy"], Rectangle(0, 120, 400, 130), font)
+			ImageUtils.drawCenteredStringOutlined(graphics, "${locale["commands.command.friendship.now"]} " + user2.name, Rectangle(0, 100, 400, 110), font)
+			ImageUtils.drawCenteredStringOutlined(graphics, locale["commands.command.friendship.isMy"], Rectangle(0, 120, 400, 130), font)
 			graphics.color = Color.MAGENTA
-			ImageUtils.drawCenteredStringOutlined(graphics, locale["commands.images.friendship.bestFriend"], Rectangle(0, 140, 400, 150), font)
+			ImageUtils.drawCenteredStringOutlined(graphics, locale["commands.command.friendship.bestFriend"], Rectangle(0, 140, 400, 150), font)
 
 			context.sendFile(template, "rip_amizade.png", context.getAsMention(true))
 		} else {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/CepoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/CepoCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class CepoCommand : AbstractCommand("cepo", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.cepo.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.cepo.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 	// TODO: Fix Usage
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/ContentAwareScaleCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/ContentAwareScaleCommand.kt
@@ -13,7 +13,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.arguments
 
 class ContentAwareScaleCommand : AbstractCommand("contentawarescale", listOf("cas", "contentaware", "seamcarver"), category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.contentawarescale.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.contentawarescale.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 	override fun getUsage() = arguments {
 		argument(ArgumentType.IMAGE) {}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DemonCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DemonCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class DemonCommand : AbstractCommand("demon", listOf("demônio", "demonio", "demónio"), category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.demon.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.demon.description")
 	override fun getExamplesKey() = Command.TWO_IMAGES_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DeusCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DeusCommand.kt
@@ -13,7 +13,7 @@ import java.awt.image.BufferedImage
 import java.io.File
 
 class DeusCommand : AbstractCommand("god", listOf("deus"), CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.god.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.god.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DeusesCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DeusesCommand.kt
@@ -22,8 +22,8 @@ class DeusesCommand : AbstractCommand("deuses", category = CommandCategory.IMAGE
 		val TEMPLATE by lazy { ImageIO.read(File(Constants.ASSETS_FOLDER, "deuses.png")) }
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.gods.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.gods.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.gods.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.gods.examples")
 	override fun getUsage() = arguments {
 		argument(ArgumentType.TEXT) {}
 	}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DiscordiaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DiscordiaCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class DiscordiaCommand : AbstractCommand("mentions", listOf("discórdia", "discord", "discordia"), CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.discordping.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.discordping.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DrawnMaskCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/DrawnMaskCommand.kt
@@ -21,7 +21,7 @@ class DrawnMaskCommand : AbstractCommand("drawnmasksign", listOf("drawnmaskplaca
 	}
 
 	override fun getDescriptionKey() = LocaleKeyData(
-			"commands.images.drawnmasksign.description",
+			"commands.command.drawnmasksign.description",
 			listOf(
 					LocaleStringData("Drawn Mask")
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/GangueCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/GangueCommand.kt
@@ -20,8 +20,8 @@ class GangueCommand : AbstractCommand("gang", listOf("gangue"), CommandCategory.
 		val TEMPLATE_OVERLAY by lazy { ImageIO.read(File(Constants.ASSETS_FOLDER, "cocielo/overlay.png")) }
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.gang.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.gang.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.gang.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.gang.examples")
 
 	// TODO: Fix Usage
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/GetOverHereCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/GetOverHereCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class GetOverHereCommand : AbstractCommand("getoverhere", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.getoverhere.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.getoverhere.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/GumballCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/GumballCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class GumballCommand : AbstractCommand("gumball", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.gumballliftup.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.gumballliftup.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/InverterCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/InverterCommand.kt
@@ -10,7 +10,7 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import java.awt.Color
 
 class InverterCommand : AbstractCommand("invert", listOf("inverter"), category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.invert.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.invert.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Detailed Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/JoojCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/JoojCommand.kt
@@ -11,7 +11,7 @@ import java.awt.geom.AffineTransform
 import java.awt.image.AffineTransformOp
 
 class JoojCommand : AbstractCommand("jooj", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.jooj.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.jooj.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Detailed Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/KnuxThrowCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/KnuxThrowCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class KnuxThrowCommand : AbstractCommand("knuxthrow", listOf("knucklesthrow", "throwknux", "throwknuckles", "knucklesjogar", "knuxjogar", "jogarknuckles", "jogarknux"), category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.knuxthrow.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.knuxthrow.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/LaranjoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/LaranjoCommand.kt
@@ -14,7 +14,7 @@ import java.awt.Font
 import java.io.File
 
 class LaranjoCommand : AbstractCommand("laranjo", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.laranjo.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.laranjo.description")
 
 	override fun getExamples(): List<String> {
 		return listOf("ei ademin bane o cara ai pfv")

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/LavaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/LavaCommand.kt
@@ -19,8 +19,8 @@ import java.awt.image.BufferedImage
 import java.io.File
 
 class LavaCommand : AbstractCommand("lava", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.lava.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.lava.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.lava.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.lava.examples")
 	override fun getUsage() = arguments {
 		argument(ArgumentType.IMAGE) {}
 		argument(ArgumentType.TEXT) {}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/LavaReversoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/LavaReversoCommand.kt
@@ -21,8 +21,8 @@ import java.awt.image.BufferedImage
 import java.io.File
 
 class LavaReversoCommand : AbstractCommand("lavareverse", listOf("lavareverso", "reverselava"), CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.reverselava.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.reverselavaqq\\.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.reverselava.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.reverselavaqq\\.examples")
 
 	override fun getUsage() = arguments {
 		argument(ArgumentType.IMAGE) {}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/ManiaTitleCardCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/ManiaTitleCardCommand.kt
@@ -15,8 +15,8 @@ import java.io.File
 import javax.imageio.ImageIO
 
 class ManiaTitleCardCommand : AbstractCommand("maniatitlecard", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.maniatitlecard.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.maniatitlecard.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.maniatitlecard.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.maniatitlecard.examples")
 	override fun getUsage() = arguments {
 		argument(ArgumentType.TEXT) {}
 	}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/NyanCatCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/NyanCatCommand.kt
@@ -27,8 +27,8 @@ class NyanCatCommand : AbstractCommand("nyan", category = CommandCategory.IMAGES
 		val DOG_EARS by lazy { ImageIO.read(File(Constants.ASSETS_FOLDER, "dog_ears.png")) }
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.nyancat.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.nyancat.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.nyancat.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.nyancat.examples")
 // TODO: Fix Usage
 
 	override fun needsToUploadFiles(): Boolean {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/OjjoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/OjjoCommand.kt
@@ -11,7 +11,7 @@ import java.awt.geom.AffineTransform
 import java.awt.image.AffineTransformOp
 
 class OjjoCommand : AbstractCommand("ojjo", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.ojjo.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.ojjo.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Detailed Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/PerdaoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/PerdaoCommand.kt
@@ -16,7 +16,7 @@ class PerdaoCommand : AbstractCommand("perdao", listOf("perdão"), CommandCatego
 		val TEMPLATE by lazy { ImageIO.read(File(Constants.ASSETS_FOLDER, "perdao.png")) }
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.forgive.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.forgive.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/PerfeitoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/PerfeitoCommand.kt
@@ -13,7 +13,7 @@ import java.io.File
 import javax.imageio.ImageIO
 
 class PerfeitoCommand : AbstractCommand("perfect", listOf("perfeito"), CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.perfect.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.perfect.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/PrimeirasPalavrasCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/PrimeirasPalavrasCommand.kt
@@ -14,8 +14,8 @@ import java.awt.Font
 import java.io.File
 
 class PrimeirasPalavrasCommand : AbstractCommand("firstwords", listOf("primeiraspalavras"), CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.firstwords.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.firstwords.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.firstwords.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.firstwords.examples")
 
 	override fun needsToUploadFiles(): Boolean {
 		return true

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/RazoesCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/RazoesCommand.kt
@@ -22,7 +22,7 @@ import java.awt.image.RGBImageFilter
 import java.io.File
 
 class RazoesCommand : AbstractCommand("reasons", listOf("razões", "razoes"), CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.reasons.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.reasons.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/RipVidaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/RipVidaCommand.kt
@@ -13,7 +13,7 @@ import java.awt.image.BufferedImage
 import java.io.File
 
 class RipVidaCommand : AbstractCommand("riplife", listOf("ripvida"), CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.ripvida.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.ripvida.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage
@@ -25,11 +25,11 @@ class RipVidaCommand : AbstractCommand("riplife", listOf("ripvida"), CommandCate
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		val contextImage = context.getImageAt(0) ?: run { Constants.INVALID_IMAGE_REPLY.invoke(context); return; }
 
-		val template = readImage(File(Loritta.ASSETS + context.locale["commands.images.ripvida.file"])) // Template
+		val template = readImage(File(Loritta.ASSETS + context.locale["commands.command.ripvida.file"])) // Template
 
 		val scaled = contextImage.getScaledInstance(133, 133, BufferedImage.SCALE_SMOOTH)
 		template.graphics.drawImage(scaled, 133, 0, null)
 
-		context.sendFile(template, context.locale["commands.images.ripvida.file"], context.getAsMention(true))
+		context.sendFile(template, context.locale["commands.command.ripvida.file"], context.getAsMention(true))
 	}
 }

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/SwingCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/SwingCommand.kt
@@ -12,7 +12,7 @@ import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class SwingCommand : AbstractCommand("swing", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.swing.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.swing.description")
 	override fun getExamplesKey() = Command.TWO_IMAGES_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TextCraftCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TextCraftCommand.kt
@@ -18,7 +18,7 @@ import javax.imageio.ImageIO
 
 class TextCraftCommand : AbstractCommand("textcraft", category = CommandCategory.IMAGES) {
 	override fun getDescriptionKey() = LocaleKeyData(
-			"commands.images.textcraft.description",
+			"commands.command.textcraft.description",
 			listOf(
 					LocaleStringData(TextCraftFont.values().joinToString(", ", transform = { it.internalName }))
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TodoGrupoTemCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TodoGrupoTemCommand.kt
@@ -22,15 +22,15 @@ import java.io.File
 import java.util.*
 
 class TodoGrupoTemCommand : AbstractCommand("everygrouphas", listOf("todogrupotem"), CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.everygrouphas.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.everygrouphas.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.everygrouphas.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.everygrouphas.examples")
 
 	override fun needsToUploadFiles(): Boolean {
 		return true
 	}
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
-		val bi = readImage(File(Loritta.ASSETS + context.locale["commands.images.everygrouphas.file"])) // Primeiro iremos carregar o nosso template
+		val bi = readImage(File(Loritta.ASSETS + context.locale["commands.command.everygrouphas.file"])) // Primeiro iremos carregar o nosso template
 
 		val base = BufferedImage(366, 266, BufferedImage.TYPE_INT_ARGB) // Iremos criar uma imagem 384x256 (tamanho do template)
 		val baseGraph = base.graphics.enableFontAntiAliasing()
@@ -57,7 +57,7 @@ class TodoGrupoTemCommand : AbstractCommand("everygrouphas", listOf("todogrupote
 
 		val font = Font.createFont(0, File(Loritta.ASSETS + "mavenpro-bold.ttf")).deriveFont(16f)
 		baseGraph.font = font
-		ImageUtils.drawCenteredStringOutlined(baseGraph, locale["commands.images.everygrouphas.everygrouphas"], Rectangle(0, 0, 366, 22), font)
+		ImageUtils.drawCenteredStringOutlined(baseGraph, locale["commands.command.everygrouphas.everygrouphas"], Rectangle(0, 0, 366, 22), font)
 
 		for (aux in 5 downTo 0) {
 			val member = users[0]

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TretaNewsCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TretaNewsCommand.kt
@@ -10,8 +10,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class TretaNewsCommand : AbstractCommand("tretanews", category = CommandCategory.FUN) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.tretanews.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.images.tretanews.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.tretanews.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.tretanews.examples")
 
 	// TODO: Fix Usage
 	// TODO: Fix Detailed Usage
@@ -36,7 +36,7 @@ class TretaNewsCommand : AbstractCommand("tretanews", category = CommandCategory
                         mentionUser = false
                 ),
                 LorittaReply(
-                        message = "\uD83D\uDCFA `${base.views}` **${context.locale["commands.fun.twitch.views"]}**, \uD83D\uDE0D `${base.likes}` **${context.locale["commands.images.tretanews.likes"]}**, \uD83D\uDE20 `${base.dislikes}` **${context.locale["commands.images.tretanews.dislikes"]}**",
+                        message = "\uD83D\uDCFA `${base.views}` **${context.locale["commands.command.twitch.views"]}**, \uD83D\uDE0D `${base.likes}` **${context.locale["commands.command.tretanews.likes"]}**, \uD83D\uDE20 `${base.dislikes}` **${context.locale["commands.command.tretanews.dislikes"]}**",
                         prefix = "\uD83D\uDCC8",
                         mentionUser = false
                 )

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TriggeredCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TriggeredCommand.kt
@@ -17,7 +17,7 @@ import java.io.File
 import javax.imageio.stream.FileImageOutputStream
 
 class TriggeredCommand : AbstractCommand("triggered", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.triggered.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.triggered.description")
 	override fun getExamplesKey() = Command.SINGLE_IMAGE_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TrumpCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/images/TrumpCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.api.commands.Command
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class TrumpCommand : AbstractCommand("trump", category = CommandCategory.IMAGES) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.images.trump.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.trump.description")
 	override fun getExamplesKey() = Command.TWO_IMAGES_EXAMPLES_KEY
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McAvatarCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McAvatarCommand.kt
@@ -11,8 +11,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class McAvatarCommand : AbstractCommand("mcavatar", category = CommandCategory.MINECRAFT) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mcavatar.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.minecraft.skinPlayerNameExamples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.mcavatar.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.category.minecraft.skinPlayerNameExamples")
 
 	// TODO: Fix Usage
 
@@ -29,7 +29,7 @@ class McAvatarCommand : AbstractCommand("mcavatar", category = CommandCategory.M
 			if (uuid == null) {
 				context.reply(
                         LorittaReply(
-                                locale["commands.minecraft.unknownPlayer", context.args.getOrNull(0)],
+                                locale["commands.category.minecraft.unknownPlayer", context.args.getOrNull(0)],
                                 Constants.ERROR
                         )
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McBodyCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McBodyCommand.kt
@@ -11,8 +11,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class McBodyCommand : AbstractCommand("mcbody", listOf("mcstatue"), CommandCategory.MINECRAFT) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mcbody.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.minecraft.skinPlayerNameExamples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.mcbody.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.category.minecraft.skinPlayerNameExamples")
 
 	// TODO: Fix Usage
 
@@ -29,7 +29,7 @@ class McBodyCommand : AbstractCommand("mcbody", listOf("mcstatue"), CommandCateg
 			if (uuid == null) {
 				context.reply(
                         LorittaReply(
-                                locale["commands.minecraft.unknownPlayer", context.args.getOrNull(0)],
+                                locale["commands.category.minecraft.unknownPlayer", context.args.getOrNull(0)],
                                 Constants.ERROR
                         )
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McConquistaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McConquistaCommand.kt
@@ -14,8 +14,8 @@ import java.awt.image.BufferedImage
 import java.io.File
 
 class McConquistaCommand : AbstractCommand("mcconquista", listOf("mcprogresso", "mcadvancement", "mcachievement"), CommandCategory.MINECRAFT) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mcadvancement.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.minecraft.mcadvancement.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.mcadvancement.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.mcadvancement.examples")
 
 	// TODO: Fix Usage
 
@@ -39,7 +39,7 @@ class McConquistaCommand : AbstractCommand("mcconquista", listOf("mcprogresso", 
 			graphics.font = minecraftia
 			graphics.color = Color(255, 255, 0)
 
-			graphics.drawString(context.locale["commands.minecraft.mcadvancement.advancementMade"], 90, 41 + 14)
+			graphics.drawString(context.locale["commands.command.mcadvancement.advancementMade"], 90, 41 + 14)
 			graphics.color = Color(255, 255, 255)
 
 			var remadeText = ""

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McHeadCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McHeadCommand.kt
@@ -11,8 +11,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class McHeadCommand : AbstractCommand("mchead", category = CommandCategory.MINECRAFT) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mchead.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.minecraft.skinPlayerNameExamples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.mchead.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.category.minecraft.skinPlayerNameExamples")
 
 	// TODO: Fix Usage
 
@@ -29,7 +29,7 @@ class McHeadCommand : AbstractCommand("mchead", category = CommandCategory.MINEC
 			if (uuid == null) {
 				context.reply(
                         LorittaReply(
-								locale["commands.minecraft.unknownPlayer", context.args.getOrNull(0)],
+								locale["commands.category.minecraft.unknownPlayer", context.args.getOrNull(0)],
                                 Constants.ERROR
                         )
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McMoletomCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McMoletomCommand.kt
@@ -17,8 +17,8 @@ import java.awt.image.BufferedImage
 import java.io.File
 
 class McMoletomCommand : AbstractCommand("mcmoletom", listOf("mcsweater"), CommandCategory.MINECRAFT) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mcsweater.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.minecraft.skinPlayerNameExamples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.mcsweater.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.category.minecraft.skinPlayerNameExamples")
 
 	// TODO: Fix Usage
 
@@ -40,7 +40,7 @@ class McMoletomCommand : AbstractCommand("mcmoletom", listOf("mcsweater"), Comma
 				if (profile == null) {
 					context.reply(
                             LorittaReply(
-									locale["commands.minecraft.unknownPlayer", context.args.getOrNull(0)],
+									locale["commands.category.minecraft.unknownPlayer", context.args.getOrNull(0)],
                                     Constants.ERROR
                             )
 					)
@@ -71,22 +71,22 @@ class McMoletomCommand : AbstractCommand("mcmoletom", listOf("mcsweater"), Comma
 
 			if (moletom == null) {
 				context.reply(
-						locale["commands.minecraft.mcsweater.invalidSkin"],
+						locale["commands.command.mcsweater.invalidSkin"],
 						Constants.ERROR
 				)
 				return
 			}
 
-			val str = "<:loritta:331179879582269451> **|** " + context.getAsMention(true) + locale["commands.minecraft.mcsweater.done"]
+			val str = "<:loritta:331179879582269451> **|** " + context.getAsMention(true) + locale["commands.command.mcsweater.done"]
 			val message = context.sendFile(moletom, "moletom.png", str)
 
 			val image = message.attachments.first()
 
-			message.editMessage(str + " " + locale["commands.minecraft.mcsweater.uploadToMojang"] + " <https://minecraft.net/pt-br/profile/skin/remote/?url=${image.url}>").queue()
+			message.editMessage(str + " " + locale["commands.command.mcsweater.uploadToMojang"] + " <https://minecraft.net/pt-br/profile/skin/remote/?url=${image.url}>").queue()
 		} else {
 			context.reply(
                     LorittaReply(
-							locale["commands.minecraft.unknownPlayer", context.args.getOrNull(0)],
+							locale["commands.category.minecraft.unknownPlayer", context.args.getOrNull(0)],
                             Constants.ERROR
                     )
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McSkinCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McSkinCommand.kt
@@ -11,8 +11,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class McSkinCommand : AbstractCommand("mcskin", listOf("skinsteal", "skinstealer"), CommandCategory.MINECRAFT) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mcskin.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.minecraft.skinPlayerNameExamples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.mcskin.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.category.minecraft.skinPlayerNameExamples")
 
 	// TODO: Fix Usage
 
@@ -29,7 +29,7 @@ class McSkinCommand : AbstractCommand("mcskin", listOf("skinsteal", "skinstealer
 			if (profile == null) {
 				context.reply(
                         LorittaReply(
-								locale["commands.minecraft.unknownPlayer", context.args.getOrNull(0)],
+								locale["commands.category.minecraft.unknownPlayer", context.args.getOrNull(0)],
                                 Constants.ERROR
                         )
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McStatusCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McStatusCommand.kt
@@ -14,13 +14,13 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import java.awt.Color
 
 class McStatusCommand : AbstractCommand("mcstatus", category = CommandCategory.MINECRAFT) {
-    override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mcstatus.description")
+    override fun getDescriptionKey() = LocaleKeyData("commands.command.mcstatus.description")
 
     override suspend fun run(context: CommandContext, locale: BaseLocale) {
         val body = HttpRequest.get("https://status.mojang.com/check").body()
 
         val builder = EmbedBuilder()
-                .setTitle("📡 ${locale["commands.minecraft.mcstatus.mojangStatus"]}", "https://help.mojang.com/")
+                .setTitle("📡 ${locale["commands.command.mcstatus.mojangStatus"]}", "https://help.mojang.com/")
                 .setColor(Color.GREEN)
 
         val json = JsonParser.parseString(body)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McUUIDCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/McUUIDCommand.kt
@@ -12,8 +12,8 @@ import com.mrpowergamerbr.loritta.utils.locale.LocaleKeyData
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class McUUIDCommand : AbstractCommand("mcuuid", category = CommandCategory.MINECRAFT) {
-    override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mcuuid.description")
-    override fun getExamplesKey() = LocaleKeyData("commands.minecraft.playerNameExamples")
+    override fun getDescriptionKey() = LocaleKeyData("commands.command.mcuuid.description")
+    override fun getExamplesKey() = LocaleKeyData("commands.category.minecraft.playerNameExamples")
 
     // TODO: Fix Usage
 
@@ -26,9 +26,9 @@ class McUUIDCommand : AbstractCommand("mcuuid", category = CommandCategory.MINEC
 	        try {
                 val json = JsonParser.parseString(data).asJsonObject
 
-	            context.sendMessage(context.getAsMention(true) + context.locale["commands.minecraft.mcuuid.result", player, LorittaUtils.getUUID(json["id"].string)])
+	            context.sendMessage(context.getAsMention(true) + context.locale["commands.command.mcuuid.result", player, LorittaUtils.getUUID(json["id"].string)])
             } catch (e: IllegalStateException) {
-                context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.minecraft.mcuuid.invalid", player])
+                context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.command.mcuuid.invalid", player])
             }
         } else {
             this.explain(context)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/OfflineUUIDCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/OfflineUUIDCommand.kt
@@ -9,8 +9,8 @@ import org.apache.commons.codec.Charsets
 import java.util.*
 
 class OfflineUUIDCommand : AbstractCommand("mcofflineuuid", listOf("offlineuuid"), CommandCategory.MINECRAFT) {
-    override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.mcofflineuuid.description")
-    override fun getExamplesKey() = LocaleKeyData("commands.minecraft.playerNameExamples")
+    override fun getDescriptionKey() = LocaleKeyData("commands.command.mcofflineuuid.description")
+    override fun getExamplesKey() = LocaleKeyData("commands.category.minecraft.playerNameExamples")
 
     // TODO: Fix Usage
 
@@ -18,7 +18,7 @@ class OfflineUUIDCommand : AbstractCommand("mcofflineuuid", listOf("offlineuuid"
         if (context.args.size == 1) {
             val uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + context.args[0]).toByteArray(Charsets.UTF_8))
 
-            context.sendMessage(context.getAsMention(true) + locale["commands.minecraft.mcofflineuuid.result", context.args[0], uuid.toString()])
+            context.sendMessage(context.getAsMention(true) + locale["commands.command.mcofflineuuid.result", context.args[0], uuid.toString()])
         } else {
             context.explain()
         }

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/SpigotMcCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/minecraft/SpigotMcCommand.kt
@@ -30,7 +30,7 @@ import java.util.*
 class SpigotMcCommand : AbstractCommand("spigotmc", category = CommandCategory.MINECRAFT) {
 	override fun getBotPermissions() = listOf(Permission.MESSAGE_MANAGE)
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.minecraft.spigotmc.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.spigotmc.description")
 
 	// TODO: Fix Usage
 
@@ -54,7 +54,7 @@ class SpigotMcCommand : AbstractCommand("spigotmc", category = CommandCategory.M
 
 			if (json.isJsonObject) {
 				// Erro!
-				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.minecraft.spigotmc.couldntFind", query])
+				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.command.spigotmc.couldntFind", query])
 				return
 			} else {
 				val array = json.array
@@ -73,7 +73,7 @@ class SpigotMcCommand : AbstractCommand("spigotmc", category = CommandCategory.M
 						context.metadata.put(i.toString(), item["id"].string)
 					}
 					embed.setDescription(format)
-					embed.setTitle("<:spigotmc:375314413357629440> ${context.locale["commands.minecraft.spigotmc.results", query]}")
+					embed.setTitle("<:spigotmc:375314413357629440> ${context.locale["commands.command.spigotmc.results", query]}")
 					val mensagem = context.sendMessage(context.getAsMention(true), embed.build())
 
 					mensagem.onReactionAddByAuthor(context) {
@@ -116,9 +116,9 @@ class SpigotMcCommand : AbstractCommand("spigotmc", category = CommandCategory.M
 		embed.setTitle("<:spigotmc:375314413357629440> ${resource.name}", "https://www.spigotmc.org/resources/$resourceId/")
 		embed.setDescription(resource.tag.replace("*", "\\*").replace("_", "\\_").replace("~", "\\~"))
 		embed.setThumbnail("https://www.spigotmc.org/${resource.icon}")
-		if (resource.contributors.isNotEmpty()) embed.addField(context.locale["commands.minecraft.spigotmc.contributors"], resource.contributors, true)
-		embed.addField(context.locale["commands.minecraft.spigotmc.downloads"], resource.downloads.toString(), true)
-		if (resource.testedVersions.isNotEmpty()) embed.addField(context.locale["commands.minecraft.spigotmc.testedVersions"], resource.testedVersions.joinToString(separator = ", "), true)
+		if (resource.contributors.isNotEmpty()) embed.addField(context.locale["commands.command.spigotmc.contributors"], resource.contributors, true)
+		embed.addField(context.locale["commands.command.spigotmc.downloads"], resource.downloads.toString(), true)
+		if (resource.testedVersions.isNotEmpty()) embed.addField(context.locale["commands.command.spigotmc.testedVersions"], resource.testedVersions.joinToString(separator = ", "), true)
 
 		val releaseEpoch = resource.releaseDate.toLong()
 		val releaseInstant = Instant.ofEpochSecond(releaseEpoch)
@@ -128,10 +128,10 @@ class SpigotMcCommand : AbstractCommand("spigotmc", category = CommandCategory.M
 		val updateInstant = Instant.ofEpochSecond(updateEpoch)
 		ZonedDateTime.ofInstant(updateInstant, ZoneOffset.UTC)
 
-		embed.addField(context.locale["commands.minecraft.spigotmc.released"], releaseInstant.atOffset(ZoneOffset.UTC).humanize(locale), true)
-		embed.addField(context.locale["commands.minecraft.spigotmc.lastUpdated"], updateInstant.atOffset(ZoneOffset.UTC).humanize(locale), true)
+		embed.addField(context.locale["commands.command.spigotmc.released"], releaseInstant.atOffset(ZoneOffset.UTC).humanize(locale), true)
+		embed.addField(context.locale["commands.command.spigotmc.lastUpdated"], updateInstant.atOffset(ZoneOffset.UTC).humanize(locale), true)
 
-		embed.addField(context.locale["commands.minecraft.spigotmc.download"], "https://www.spigotmc.org/${resource.downloadLink}", true)
+		embed.addField(context.locale["commands.command.spigotmc.download"], "https://www.spigotmc.org/${resource.downloadLink}", true)
 
 		return embed
 	}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/AjudaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/AjudaCommand.kt
@@ -11,39 +11,39 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.utils.Emotes
 
 class AjudaCommand : AbstractCommand("ajuda", listOf("help", "comandos", "commands"), CommandCategory.MISC) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.misc.help.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.help.description")
 
 	override suspend fun run(context: CommandContext, locale: BaseLocale) {
 		val embed = EmbedBuilder()
-				.setTitle("${Emotes.LORI_HEART} ${context.locale["commands.misc.help.lorittaHelp"]}")
-				.setDescription(context.locale.getList("commands.misc.help.intro").joinToString("\n\n", transform = { it.replace("{0}", context.asMention) }))
+				.setTitle("${Emotes.LORI_HEART} ${context.locale["commands.command.help.lorittaHelp"]}")
+				.setDescription(context.locale.getList("commands.command.help.intro").joinToString("\n\n", transform = { it.replace("{0}", context.asMention) }))
 				.addField(
-						"${Emotes.LORI_PAT} ${context.locale["commands.misc.help.commandList"]}",
+						"${Emotes.LORI_PAT} ${context.locale["commands.command.help.commandList"]}",
 						"${loritta.instanceConfig.loritta.website.url}commands",
 						false
 				)
 				.addField(
-						"${Emotes.LORI_HM} ${context.locale["commands.misc.help.supportServer"]}",
+						"${Emotes.LORI_HM} ${context.locale["commands.command.help.supportServer"]}",
 						"${loritta.instanceConfig.loritta.website.url}support",
 						false
 				)
 				.addField(
-						"${Emotes.LORI_YAY} ${context.locale["commands.misc.help.addMe"]}",
+						"${Emotes.LORI_YAY} ${context.locale["commands.command.help.addMe"]}",
 						"${loritta.instanceConfig.loritta.website.url}dashboard",
 						false
 				)
 				.addField(
-						"${Emotes.LORI_RICH} ${context.locale["commands.misc.help.donate"]}",
+						"${Emotes.LORI_RICH} ${context.locale["commands.command.help.donate"]}",
 						"${loritta.instanceConfig.loritta.website.url}donate",
 						false
 				)
 				.addField(
-						"${Emotes.LORI_TEMMIE} ${context.locale["commands.misc.help.blog"]}",
+						"${Emotes.LORI_TEMMIE} ${context.locale["commands.command.help.blog"]}",
 						"${loritta.instanceConfig.loritta.website.url}blog",
 						false
 				)
 				.addField(
-						"${Emotes.LORI_RAGE} ${context.locale["commands.misc.help.guidelines"]}",
+						"${Emotes.LORI_RAGE} ${context.locale["commands.command.help.guidelines"]}",
 						"${loritta.instanceConfig.loritta.website.url}guidelines",
 						false
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/DiscordBotListCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/DiscordBotListCommand.kt
@@ -10,14 +10,14 @@ import net.dv8tion.jda.api.EmbedBuilder
 import net.perfectdreams.loritta.api.commands.CommandCategory
 
 class DiscordBotListCommand : AbstractCommand("discordbotlist", listOf("dbl", "upvote"), category = CommandCategory.MISC) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.misc.dbl.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.dbl.description")
 
     override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		val embed = EmbedBuilder().apply {
 			setColor(Constants.LORITTA_AQUA)
 			setThumbnail("${loritta.instanceConfig.loritta.website.url}assets/img/loritta_star.png")
 			setTitle("✨ Discord Bot List")
-			setDescription(locale["commands.misc.dbl.info", context.config.commandPrefix, "https://discordbots.org/bot/loritta"])
+			setDescription(locale["commands.command.dbl.info", context.config.commandPrefix, "https://discordbots.org/bot/loritta"])
 		}
 
 	    context.sendMessage(context.getAsMention(true), embed.build())

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/EscolherCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/EscolherCommand.kt
@@ -10,8 +10,8 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
 class EscolherCommand : AbstractCommand("choose", listOf("escolher"), category = CommandCategory.MISC) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.misc.choose.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.misc.choose.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.choose.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.choose.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		if (context.args.isNotEmpty()) {
@@ -22,7 +22,7 @@ class EscolherCommand : AbstractCommand("choose", listOf("escolher"), category =
 			val chosen = split[Loritta.RANDOM.nextInt(split.size)]
 			context.reply(
                     LorittaReply(
-                            message = context.locale["commands.misc.choose.result", chosen],
+                            message = context.locale["commands.command.choose.result", chosen],
                             prefix = Emotes.LORI_HM
                     )
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/LanguageCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/LanguageCommand.kt
@@ -22,7 +22,7 @@ class LanguageCommand : AbstractCommand("language", listOf("linguagem", "speak",
     private val resetPersonalLanguageEmote = "\uD83D\uDE45"
 
     override fun getDescriptionKey() = LocaleKeyData(
-            "commands.misc.language.description",
+            "commands.command.language.description",
             listOf(
                     LocaleStringData("\uD83D\uDE0A")
             )
@@ -150,7 +150,7 @@ class LanguageCommand : AbstractCommand("language", listOf("linguagem", "speak",
                 }
                 context.reply(
                         LorittaReply(
-                                locale["commands.misc.language.removedPersonalLanguage"]
+                                locale["commands.command.language.removedPersonalLanguage"]
                         )
                 )
                 return@onReactionAddByAuthor
@@ -195,37 +195,37 @@ class LanguageCommand : AbstractCommand("language", listOf("linguagem", "speak",
         }
 
         if (isPrivateChannel)
-            context.reply(newLocale["commands.misc.language.languageChanged", "`${localeId}`"], "\uD83C\uDFA4")
+            context.reply(newLocale["commands.command.language.languageChanged", "`${localeId}`"], "\uD83C\uDFA4")
         else
-            context.reply(newLocale["commands.misc.language.serverLanguageChanged", "`${localeId}`"], "\uD83C\uDFA4")
+            context.reply(newLocale["commands.command.language.serverLanguageChanged", "`${localeId}`"], "\uD83C\uDFA4")
     }
 
     private suspend fun buildLanguageEmbed(locale: BaseLocale, languages: List<LocaleWrapper>, isPrivateChannel: Boolean, hasPersonalLanguage: Boolean): MessageEmbed {
         val embed = EmbedBuilder()
         embed.setColor(Color(0, 193, 223))
-        embed.setTitle("\uD83C\uDF0E " + locale["commands.misc.language.pleaseSelectYourLanguage"])
+        embed.setTitle("\uD83C\uDF0E " + locale["commands.command.language.pleaseSelectYourLanguage"])
 
         if (isPrivateChannel) {
-            embed.setDescription(locale["commands.misc.language.changeLanguageDescription"])
+            embed.setDescription(locale["commands.command.language.changeLanguageDescription"])
         } else {
-            embed.setDescription(locale["commands.misc.language.changeServerLanguageDescription"])
-            embed.setFooter(locale["commands.misc.language.personalLanguageTip"])
+            embed.setDescription(locale["commands.command.language.changeServerLanguageDescription"])
+            embed.setFooter(locale["commands.command.language.personalLanguageTip"])
         }
 
         if (hasPersonalLanguage)
-            embed.setFooter(locale["commands.misc.language.personalLanguageRemovalTip", resetPersonalLanguageEmote])
+            embed.setFooter(locale["commands.command.language.personalLanguageRemovalTip", resetPersonalLanguageEmote])
 
         for (wrapper in languages) {
             val translators = wrapper.locale.getList("loritta.translationAuthors").mapNotNull { lorittaShards.retrieveUserInfoById(it.toLong()) }
 
             embed.addField(
                     wrapper.emoteName + " " + wrapper.name,
-                    "**${locale["commands.misc.language.translatedBy"]}:** ${translators.joinToString(transform = { "`${it.name}`" })}",
+                    "**${locale["commands.command.language.translatedBy"]}:** ${translators.joinToString(transform = { "`${it.name}`" })}",
                     true
             )
         }
         embed.addField(
-                locale["commands.misc.language.helpUsTranslate"],
+                locale["commands.command.language.helpUsTranslate"],
                 loritta.config.crowdin.url,
                 false
         )

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/PatreonCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/PatreonCommand.kt
@@ -11,17 +11,17 @@ import net.perfectdreams.loritta.utils.Emotes
 import java.awt.Color
 
 class PatreonCommand : AbstractCommand("donator", listOf("donators", "patreons", "patreon", "doadores", "doador", "apoiador", "apoiadores", "contribuidores", "contribuidor", "doar", "donate"), category = CommandCategory.MISC) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.misc.donate.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.donate.description")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		val patrons = "Veja todos os doadores em https://loritta.website/donate (tem tantos doadores que não cabe nesta mensagem! ${Emotes.LORI_CRYING})"
 
 		val embed = EmbedBuilder().apply {
 			setThumbnail("https://loritta.website/assets/img/fanarts/Loritta_-_Heathecliff.png")
-			setTitle("${Emotes.LORI_RICH} ${context.locale["commands.misc.donate.thanks"]}")
+			setTitle("${Emotes.LORI_RICH} ${context.locale["commands.command.donate.thanks"]}")
 			setColor(Color(0, 193, 223))
 			setDescription(patrons)
-			addField("\uD83C\uDF80 " + context.locale["commands.misc.donate.doYouWannaHelp"], context.locale["commands.misc.donate.howToHelp", "${loritta.instanceConfig.loritta.website.url}donate", Emotes.LORI_HEART, Emotes.LORI_CRYING, Emotes.LORI_RICH], false)
+			addField("\uD83C\uDF80 " + context.locale["commands.command.donate.doYouWannaHelp"], context.locale["commands.command.donate.howToHelp", "${loritta.instanceConfig.loritta.website.url}donate", Emotes.LORI_HEART, Emotes.LORI_CRYING, Emotes.LORI_RICH], false)
 		}
 
 		context.sendMessage(context.getAsMention(true), embed.build())

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/PingCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/misc/PingCommand.kt
@@ -29,7 +29,7 @@ import net.perfectdreams.loritta.utils.extensions.build
 import java.util.concurrent.TimeUnit
 
 class PingCommand : AbstractCommand("ping", category = CommandCategory.MISC) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.misc.ping.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.ping.description")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		val arg0 = context.args.getOrNull(0)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/music/LyricsCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/music/LyricsCommand.kt
@@ -35,8 +35,8 @@ import java.io.IOException
 import javax.imageio.ImageIO
 
 class LyricsCommand : AbstractCommand("lyrics", listOf("letra", "letras"), category = CommandCategory.UTILS) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.lyrics.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.utils.lyrics.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.lyrics.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.lyrics.examples")
 
 	// TODO: Fix Usage
 
@@ -60,7 +60,7 @@ class LyricsCommand : AbstractCommand("lyrics", listOf("letra", "letras"), categ
 			if (songInfo == null) {
 				context.reply(
                         LorittaReply(
-                                "${locale["commands.utils.lyrics.couldntFind"]} ${locale["commands.utils.lyrics.sorryForTheInconvenience"]} \uD83D\uDE2D",
+                                "${locale["commands.command.lyrics.couldntFind"]} ${locale["commands.command.lyrics.sorryForTheInconvenience"]} \uD83D\uDE2D",
                                 Constants.ERROR
                         )
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/pokemon/PokedexCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/pokemon/PokedexCommand.kt
@@ -13,7 +13,7 @@ import java.awt.Color
 import java.util.*
 
 class PokedexCommand : AbstractCommand("pokedex", listOf("pokédex"), CommandCategory.POKEMON) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.pokemon.pokedex.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.pokedex.description")
 
     override fun getExamples(): List<String> {
         return Arrays.asList("Pikachu")
@@ -61,11 +61,11 @@ class PokedexCommand : AbstractCommand("pokedex", listOf("pokédex"), CommandCat
 			var strAbilities = ""
 	        var strDexTypes = dexTypes.joinToString(separator = ", ", transform = { it.attr("alt") })
 
-	        embed.addField(locale["commands.pokemon.pokedex.types"], strDexTypes, true)
+	        embed.addField(locale["commands.command.pokedex.types"], strDexTypes, true)
 
-	        embed.addField(locale["commands.pokemon.pokedex.addedInGen"], pokeInfoValue[0].getElementsByTag("img")[0].attr("alt"), true)
+	        embed.addField(locale["commands.command.pokedex.addedInGen"], pokeInfoValue[0].getElementsByTag("img")[0].attr("alt"), true)
 
-			embed.addField(locale["commands.pokemon.pokedex.number"], pokeInfoValue[1].text(), true)
+			embed.addField(locale["commands.command.pokedex.number"], pokeInfoValue[1].text(), true)
 
 			for (el in abilities) {
 				// title
@@ -74,15 +74,15 @@ class PokedexCommand : AbstractCommand("pokedex", listOf("pokédex"), CommandCat
 				strAbilities += "**$title** - $description\n"
 			}
 
-			embed.addField(locale["commands.pokemon.pokedex.abilities"], strAbilities, true)
+			embed.addField(locale["commands.command.pokedex.abilities"], strAbilities, true)
 
-	        var strTraining = "**${context.locale["commands.pokemon.pokedex.baseExp"]}:** ${trainingInfoValue[0].text()}" +
-					"\n**${locale["commands.pokemon.pokedex.effortPoints"]}:** ${trainingInfoValue[1].text()}" +
-					"\n**${locale["commands.pokemon.pokedex.captureRate"]}:** ${trainingInfoValue[2].text()}" +
-					"\n**${locale["commands.pokemon.pokedex.baseHappiness"]}:** ${trainingInfoValue[3].text()}" +
-					"\n**${locale["commands.pokemon.pokedex.growthRate"]}:** ${trainingInfoValue[4].text()}"
+	        var strTraining = "**${context.locale["commands.command.pokedex.baseExp"]}:** ${trainingInfoValue[0].text()}" +
+					"\n**${locale["commands.command.pokedex.effortPoints"]}:** ${trainingInfoValue[1].text()}" +
+					"\n**${locale["commands.command.pokedex.captureRate"]}:** ${trainingInfoValue[2].text()}" +
+					"\n**${locale["commands.command.pokedex.baseHappiness"]}:** ${trainingInfoValue[3].text()}" +
+					"\n**${locale["commands.command.pokedex.growthRate"]}:** ${trainingInfoValue[4].text()}"
 
-	        embed.addField("${locale["commands.pokemon.pokedex.training"]}", strTraining, true)
+	        embed.addField("${locale["commands.command.pokedex.training"]}", strTraining, true)
 
 			var strEvolutions = ""
 
@@ -103,7 +103,7 @@ class PokedexCommand : AbstractCommand("pokedex", listOf("pokédex"), CommandCat
 				}
 			}
 
-			embed.addField("${locale["commands.pokemon.pokedex.evolutions"]}", strEvolutions, true)
+			embed.addField("${locale["commands.command.pokedex.evolutions"]}", strEvolutions, true)
 
 			context.sendMessage(embed.build())
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/AfkCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/AfkCommand.kt
@@ -12,8 +12,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class AfkCommand : AbstractCommand("afk", listOf("awayfromthekeyboard"), CommandCategory.SOCIAL) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.social.afk.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.social.afk.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.afk.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.afk.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		var profile = context.lorittaUser.profile
@@ -26,7 +26,7 @@ class AfkCommand : AbstractCommand("afk", listOf("awayfromthekeyboard"), Command
 
 			context.reply(
                     LorittaReply(
-                            message = context.locale["commands.social.afk.afkOff"],
+                            message = context.locale["commands.command.afk.afkOff"],
                             prefix = "\uD83D\uDC24"
                     )
 			)
@@ -45,7 +45,7 @@ class AfkCommand : AbstractCommand("afk", listOf("awayfromthekeyboard"), Command
 
 			context.reply(
                     LorittaReply(
-                            message = context.locale["commands.social.afk.afkOn"],
+                            message = context.locale["commands.command.afk.afkOn"],
                             prefix = "\uD83D\uDE34"
                     )
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/BackgroundCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/BackgroundCommand.kt
@@ -10,7 +10,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.utils.Emotes
 
 class BackgroundCommand : AbstractCommand("background", listOf("papeldeparede"), CommandCategory.SOCIAL) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.social.background.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.background.description")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		context.reply(

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/DivorceCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/DivorceCommand.kt
@@ -20,7 +20,7 @@ import org.jetbrains.exposed.sql.update
 
 class DivorceCommand : AbstractCommand("divorce", listOf("divorciar"), CommandCategory.SOCIAL) {
 	companion object {
-		const val LOCALE_PREFIX = "commands.social.divorce"
+		const val LOCALE_PREFIX = "commands.command.divorce"
 		const val DIVORCE_REACTION_EMOJI = "\uD83D\uDC94"
 		const val DIVORCE_EMBED_URI = "https://cdn.discordapp.com/emojis/556524143281963008.png?size=2048"
 	}
@@ -32,7 +32,7 @@ class DivorceCommand : AbstractCommand("divorce", listOf("divorciar"), CommandCa
 			// If the user doesn't have any profile, then he won't have any marriage anyway
 			context.reply(
 					LorittaReply(
-							locale["commands.social.youAreNotMarried", "`${context.config.commandPrefix}casar`", Emotes.LORI_HUG],
+							locale["commands.category.social.youAreNotMarried", "`${context.config.commandPrefix}casar`", Emotes.LORI_HUG],
 							Constants.ERROR
 					)
 			)
@@ -43,7 +43,7 @@ class DivorceCommand : AbstractCommand("divorce", listOf("divorciar"), CommandCa
 			// Now that's for when the marriage doesn't exist
 			context.reply(
 					LorittaReply(
-							locale["commands.social.youAreNotMarried", "`${context.config.commandPrefix}casar`", Emotes.LORI_HUG],
+							locale["commands.category.social.youAreNotMarried", "`${context.config.commandPrefix}casar`", Emotes.LORI_HUG],
 							Constants.ERROR
 					)
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/EditarXPCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/EditarXPCommand.kt
@@ -12,8 +12,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.arguments
 
 class EditarXPCommand : AbstractCommand("editxp", listOf("editarxp"), category = CommandCategory.SOCIAL) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.social.editxp.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.social.editxp.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.editxp.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.editxp.examples")
 
 	override fun canUseInPrivateChannel(): Boolean {
 		return false
@@ -39,7 +39,7 @@ class EditarXPCommand : AbstractCommand("editxp", listOf("editarxp"), category =
 			}
 
 			if (0 > newXp) {
-				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.social.editxp.moreThanZero"])
+				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.command.editxp.moreThanZero"])
 				return
 			}
 
@@ -49,7 +49,7 @@ class EditarXPCommand : AbstractCommand("editxp", listOf("editarxp"), category =
 				userData.xp = newXp
 			}
 
-			context.sendMessage(context.getAsMention(true) + context.locale["commands.social.editxp.success", user.asMention])
+			context.sendMessage(context.getAsMention(true) + context.locale["commands.command.editxp.success", user.asMention])
 		} else {
 			context.explain()
 		}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/GenderCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/GenderCommand.kt
@@ -13,12 +13,12 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class GenderCommand : AbstractCommand("gender", listOf("gênero", "genero"), CommandCategory.SOCIAL) {
-    override fun getDescriptionKey() = LocaleKeyData("commands.social.gender.description")
+    override fun getDescriptionKey() = LocaleKeyData("commands.command.gender.description")
 
     override suspend fun run(context: CommandContext, locale: BaseLocale) {
         val embed = EmbedBuilder()
-                .setTitle(locale["commands.social.gender.whatAreYou"])
-                .setDescription(locale["commands.social.gender.whyShouldYouSelect"])
+                .setTitle(locale["commands.command.gender.whatAreYou"])
+                .setDescription(locale["commands.command.gender.whyShouldYouSelect"])
                 .build()
 
 
@@ -38,7 +38,7 @@ class GenderCommand : AbstractCommand("gender", listOf("gênero", "genero"), Com
 
                 context.reply(
 						LorittaReply(
-								locale["commands.social.gender.successfullyChanged"],
+								locale["commands.command.gender.successfullyChanged"],
 								"\uD83C\uDF89"
 						)
 				)
@@ -52,7 +52,7 @@ class GenderCommand : AbstractCommand("gender", listOf("gênero", "genero"), Com
 
                 context.reply(
 						LorittaReply(
-								locale["commands.social.gender.successfullyChanged"],
+								locale["commands.command.gender.successfullyChanged"],
 								"\uD83C\uDF89"
 						)
 				)
@@ -65,7 +65,7 @@ class GenderCommand : AbstractCommand("gender", listOf("gênero", "genero"), Com
 
                 context.reply(
 						LorittaReply(
-								locale["commands.social.gender.successfullyChanged"],
+								locale["commands.command.gender.successfullyChanged"],
 								"\uD83C\uDF89"
 						)
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/MarryCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/MarryCommand.kt
@@ -19,8 +19,8 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 		val MARRIAGE_COST = 15_000
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.social.marry.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.social.marry.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.marry.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.marry.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		val proposeTo = context.getUserAt(0)
@@ -35,7 +35,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 			if (proposeTo.id == context.userHandle.id) {
 				context.reply(
                         LorittaReply(
-                                locale["commands.social.marry.cantMarryYourself"],
+                                locale["commands.command.marry.cantMarryYourself"],
                                 Constants.ERROR
                         )
 				)
@@ -45,7 +45,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 			if (proposeTo.id == loritta.discordConfig.discord.clientId) {
 				context.reply(
                         LorittaReply(
-                                locale["commands.social.marry.marryLoritta"],
+                                locale["commands.command.marry.marryLoritta"],
                                 "<:smol_lori_putassa:395010059157110785>"
                         )
 				)
@@ -56,7 +56,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 				// Já está casado!
 				context.reply(
                         LorittaReply(
-                                locale["commands.social.marry.alreadyMarried", context.config.commandPrefix],
+                                locale["commands.command.marry.alreadyMarried", context.config.commandPrefix],
                                 Constants.ERROR
                         )
 				)
@@ -67,7 +67,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 				// Já está casado!
 				context.reply(
                         LorittaReply(
-                                locale["commands.social.marry.alreadyMarriedOther", proposeTo.asMention],
+                                locale["commands.command.marry.alreadyMarriedOther", proposeTo.asMention],
                                 Constants.ERROR
                         )
 				)
@@ -79,7 +79,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 				val diff = splitCost - context.lorittaUser.profile.money
 				context.reply(
                         LorittaReply(
-                                locale["commands.social.marry.insufficientFunds", diff],
+                                locale["commands.command.marry.insufficientFunds", diff],
                                 Constants.ERROR
                         )
 				)
@@ -91,7 +91,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 				val diff = splitCost - proposeToProfile.money
 				context.reply(
                         LorittaReply(
-                                locale["commands.social.marry.insufficientFundsOther", proposeTo.asMention, diff],
+                                locale["commands.command.marry.insufficientFundsOther", proposeTo.asMention, diff],
                                 Constants.ERROR
                         )
 				)
@@ -125,7 +125,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 					if (proposeTo.id == context.userHandle.id) {
 						context.reply(
                                 LorittaReply(
-                                        locale["commands.social.marry.cantMarryYourself"],
+                                        locale["commands.command.marry.cantMarryYourself"],
                                         Constants.ERROR
                                 )
 						)
@@ -135,7 +135,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 					if (proposeTo.id == loritta.discordConfig.discord.clientId) {
 						context.reply(
                                 LorittaReply(
-                                        locale["commands.social.marry.loritta"],
+                                        locale["commands.command.marry.loritta"],
                                         "<:smol_lori_putassa:395010059157110785>"
                                 )
 						)
@@ -146,7 +146,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 						// Não tem dinheiro suficiente!
 						context.reply(
                                 LorittaReply(
-                                        locale["commands.social.marry.alreadyMarried"],
+                                        locale["commands.command.marry.alreadyMarried"],
                                         Constants.ERROR
                                 )
 						)
@@ -157,7 +157,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 						// Já está casado!
 						context.reply(
                                 LorittaReply(
-                                        locale["commands.social.marry.alreadyMarriedOther"],
+                                        locale["commands.command.marry.alreadyMarriedOther"],
                                         Constants.ERROR
                                 )
 						)
@@ -169,7 +169,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 						val diff = splitCost - profile.money
 						context.reply(
                                 LorittaReply(
-                                        locale["commands.social.marry.insufficientFunds", diff],
+                                        locale["commands.command.marry.insufficientFunds", diff],
                                         Constants.ERROR
                                 )
 						)
@@ -181,7 +181,7 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 						val diff = splitCost - proposeToProfile.money
 						context.reply(
                                 LorittaReply(
-                                        locale["commands.social.marry.insufficientFundsOther", proposeTo.asMention, diff],
+                                        locale["commands.command.marry.insufficientFundsOther", proposeTo.asMention, diff],
                                         Constants.ERROR
                                 )
 						)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/PerfilCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/PerfilCommand.kt
@@ -197,8 +197,8 @@ class PerfilCommand : AbstractCommand("profile", listOf("perfil"), CommandCatego
 		}
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.social.profile.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.social.profile.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.profile.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.profile.examples")
 
 	override fun canUseInPrivateChannel(): Boolean {
 		return false
@@ -260,7 +260,7 @@ class PerfilCommand : AbstractCommand("profile", listOf("perfil"), CommandCatego
 			return
 		}
 		if (contextUser == null && context.args.isNotEmpty() && (context.args.first() == "shop" || context.args.first() == "loja")) {
-			context.reply(LorittaReply(context.locale["commands.social.profile.profileshop", "${loritta.instanceConfig.loritta.website.url}user/@me/dashboard/profiles"], Emotes.LORI_OWO))
+			context.reply(LorittaReply(context.locale["commands.command.profile.profileshop", "${loritta.instanceConfig.loritta.website.url}user/@me/dashboard/profiles"], Emotes.LORI_OWO))
 			return
 		}
 
@@ -278,7 +278,7 @@ class PerfilCommand : AbstractCommand("profile", listOf("perfil"), CommandCatego
 		var aboutMe: String? = null
 
 		if (userProfile.userId == loritta.discordConfig.discord.clientId.toLong()) {
-			aboutMe = locale["commands.social.profile.lorittaDescription"]
+			aboutMe = locale["commands.command.profile.lorittaDescription"]
 		}
 
 		if (userProfile.userId == 390927821997998081L) {
@@ -325,7 +325,7 @@ class PerfilCommand : AbstractCommand("profile", listOf("perfil"), CommandCatego
 		)
 
 		if (images.size == 1) {
-			context.sendFile(images.first(), "lori_profile.png", "📝 **|** " + context.getAsMention(true) + context.locale["commands.social.profile.profile"]) // E agora envie o arquivo
+			context.sendFile(images.first(), "lori_profile.png", "📝 **|** " + context.getAsMention(true) + context.locale["commands.command.profile.profile"]) // E agora envie o arquivo
 		} else {
 			// Montar a GIF
 			val fileName = Loritta.TEMP + "profile-" + System.currentTimeMillis() + ".gif"
@@ -342,7 +342,7 @@ class PerfilCommand : AbstractCommand("profile", listOf("perfil"), CommandCatego
 			val outputFile = File(fileName)
 			MiscUtils.optimizeGIF(outputFile)
 
-			context.sendFile(outputFile, "lori_profile.gif", "📝 **|** " + context.getAsMention(true) + context.locale["commands.social.profile.profile"]) // E agora envie o arquivo
+			context.sendFile(outputFile, "lori_profile.gif", "📝 **|** " + context.getAsMention(true) + context.locale["commands.command.profile.profile"]) // E agora envie o arquivo
 		}
 	}
 }

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/RankCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/RankCommand.kt
@@ -17,7 +17,7 @@ import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.update
 
 class RankCommand : AbstractCommand("rank", listOf("top", "leaderboard", "ranking"), CommandCategory.SOCIAL) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.social.rank.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.rank.description")
 
 	override fun canUseInPrivateChannel(): Boolean {
 		return false

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/RepCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/RepCommand.kt
@@ -18,8 +18,8 @@ import net.perfectdreams.loritta.utils.AccountUtils
 import net.perfectdreams.loritta.utils.Emotes
 
 class RepCommand : AbstractCommand("rep", listOf("reputation", "reputação", "reputacao"), CommandCategory.SOCIAL) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.social.reputation.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.social.reputation.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.reputation.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.reputation.examples")
 
 	override fun canUseInPrivateChannel(): Boolean {
 		return false
@@ -44,7 +44,7 @@ class RepCommand : AbstractCommand("rep", listOf("reputation", "reputação", "r
 
 			if (3_600_000 > diff) {
 				val fancy = DateUtils.formatDateDiff(lastReputationGiven.receivedAt + 3.6e+6.toLong(), locale)
-				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.social.reputation.wait", fancy])
+				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.command.reputation.wait", fancy])
 				return
 			}
 		}
@@ -53,7 +53,7 @@ class RepCommand : AbstractCommand("rep", listOf("reputation", "reputação", "r
 			if (user == context.userHandle) {
 				context.reply(
                         LorittaReply(
-                                message = locale["commands.social.reputation.repSelf"],
+                                message = locale["commands.command.reputation.repSelf"],
                                 prefix = Constants.ERROR
                         )
 				)
@@ -78,7 +78,7 @@ class RepCommand : AbstractCommand("rep", listOf("reputation", "reputação", "r
 
 			context.reply(
                     LorittaReply(
-                            locale["commands.social.reputation.reputationLink", url],
+                            locale["commands.command.reputation.reputationLink", url],
                             Emotes.LORI_HAPPY
                     )
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/SobreMimCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/SobreMimCommand.kt
@@ -10,8 +10,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.commands.arguments
 
 class SobreMimCommand : AbstractCommand("aboutme", listOf("sobremim"), CommandCategory.SOCIAL) {
-    override fun getDescriptionKey() = LocaleKeyData("commands.social.aboutme.description")
-    override fun getExamplesKey() = LocaleKeyData("commands.social.aboutme.examples")
+    override fun getDescriptionKey() = LocaleKeyData("commands.command.aboutme.description")
+    override fun getExamplesKey() = LocaleKeyData("commands.command.aboutme.examples")
 
     override fun getUsage() = arguments {
         argument(ArgumentType.TEXT) {}
@@ -24,7 +24,7 @@ class SobreMimCommand : AbstractCommand("aboutme", listOf("sobremim"), CommandCa
 	            settings.aboutMe = context.args.joinToString(" ")
             }
 
-            context.sendMessage(context.getAsMention(true) + context.locale["commands.social.aboutme.changed", settings.aboutMe])
+            context.sendMessage(context.getAsMention(true) + context.locale["commands.command.aboutme.changed", settings.aboutMe])
         } else {
             this.explain(context)
         }

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/undertale/UndertaleBattleCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/undertale/UndertaleBattleCommand.kt
@@ -17,7 +17,7 @@ import java.io.File
 import java.util.*
 
 class UndertaleBattleCommand : AbstractCommand("utbattle", listOf("undertalebattle"), CommandCategory.UNDERTALE) {
-    override fun getDescriptionKey() = LocaleKeyData("commands.undertale.utbattle.description")
+    override fun getDescriptionKey() = LocaleKeyData("commands.command.utbattle.description")
 
     override fun getExamples(): List<String> {
         return Arrays.asList("Asriel Chara, are you there?")

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/undertale/UndertaleBoxCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/undertale/UndertaleBoxCommand.kt
@@ -20,7 +20,7 @@ import java.io.File
 import java.io.IOException
 
 class UndertaleBoxCommand : AbstractCommand("utbox", listOf("undertalebox"), CommandCategory.UNDERTALE) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.undertale.utbox.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.utbox.description")
 
 	override fun getExamples(): List<String> {
 		return listOf("@Loritta Legendary being made of every SOUL in the underground.")

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/AnagramaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/AnagramaCommand.kt
@@ -14,7 +14,7 @@ import net.perfectdreams.loritta.utils.Emotes
 
 class AnagramaCommand : AbstractCommand("anagram", listOf("anagrama"), CommandCategory.UTILS) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.utils.anagram"
+		private const val LOCALE_PREFIX = "commands.command.anagram"
 	}
 
 	override fun getUsage() = arguments {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/CalculadoraCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/CalculadoraCommand.kt
@@ -12,7 +12,7 @@ import net.perfectdreams.loritta.utils.math.MathUtils
 
 class CalculadoraCommand : AbstractCommand("calc", listOf("calculadora", "calculator", "calcular", "calculate"), CommandCategory.UTILS) {
 	companion object {
-		const val LOCALE_PREFIX = "commands.utils.calc"
+		const val LOCALE_PREFIX = "commands.command.calc"
 	}
 
 	// TODO: Fix Usage

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/ColorInfoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/ColorInfoCommand.kt
@@ -21,7 +21,7 @@ class ColorInfoCommand : AbstractCommand("colorinfo", listOf("rgb", "hexcolor", 
 	companion object {
 		val COLOR_UTILS = com.mrpowergamerbr.loritta.utils.ColorUtils()
 		const val FACTOR = 0.7
-		private const val LOCALE_PREFIX = "commands.utils.colorinfo"
+		private const val LOCALE_PREFIX = "commands.command.colorinfo"
 	}
 
 	override fun getDescriptionKey() = LocaleKeyData("$LOCALE_PREFIX.description")

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/DicioCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/DicioCommand.kt
@@ -16,8 +16,8 @@ import java.net.URLEncoder
 class DicioCommand : AbstractCommand("dicio", listOf("dicionário", "dicionario", "definir"), CommandCategory.UTILS) {
 	// TODO: Fix Usage
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.dicio.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.utils.dicio.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.dicio.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.dicio.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		if (context.args.size == 1) {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/EncodeCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/EncodeCommand.kt
@@ -16,7 +16,7 @@ import java.util.*
 
 class EncodeCommand : AbstractCommand("encode", listOf("codificar", "encrypt", "criptografar", "hash"), CommandCategory.UTILS) {
 	override fun getDescriptionKey() = LocaleKeyData(
-			"commands.utils.encode.description",
+			"commands.command.encode.description",
 			listOf(
 					LocaleStringData(
 							listOf("md2", "md5", "sha1", "sha256", "sha384", "sha512", "rot13", "uuid", "base64").joinToString(", ", transform = { "`$it`" })
@@ -24,7 +24,7 @@ class EncodeCommand : AbstractCommand("encode", listOf("codificar", "encrypt", "
 			)
 	)
 
-	override fun getExamplesKey() = LocaleKeyData("commands.utils.encode.examples")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.encode.examples")
 
 	// TODO: Fix Detailed Usage
 	override fun getUsage() = arguments {
@@ -67,7 +67,7 @@ class EncodeCommand : AbstractCommand("encode", listOf("codificar", "encrypt", "
 
 		if (encodedText == null) {
 			context.reply(
-					locale["commands.utils.encode.invalidMethod", encodeMode.stripCodeMarks()],
+					locale["commands.command.encode.invalidMethod", encodeMode.stripCodeMarks()],
 					Constants.ERROR
 			)
 			return
@@ -76,12 +76,12 @@ class EncodeCommand : AbstractCommand("encode", listOf("codificar", "encrypt", "
 		context.reply(
 				true,
 				LorittaReply(
-						"**${locale["commands.utils.encode.originalText"]}:** `${text.stripCodeMarks()}`",
+						"**${locale["commands.command.encode.originalText"]}:** `${text.stripCodeMarks()}`",
 						"\uD83D\uDCC4",
 						mentionUser = false
 				),
 				LorittaReply(
-						"**${locale["commands.utils.encode.encodedText"]}:** `${encodedText.stripCodeMarks()}`",
+						"**${locale["commands.command.encode.encodedText"]}:** `${encodedText.stripCodeMarks()}`",
 						"<:blobspy:465979979876794368>",
 						mentionUser = false
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/LembrarCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/LembrarCommand.kt
@@ -192,7 +192,7 @@ class LembrarCommand : AbstractCommand("remindme", listOf("lembre", "remind", "l
 	}
 
 	private companion object {
-		private const val LOCALE_PREFIX = "commands.utils.remindme"
+		private const val LOCALE_PREFIX = "commands.command.remindme"
 	}
 }
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/MoneyCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/MoneyCommand.kt
@@ -47,8 +47,8 @@ class MoneyCommand : AbstractCommand("money", listOf("dinheiro", "grana"), Comma
 		}
 	}
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.money.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.utils.money.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.money.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.money.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		if (context.args.size >= 2) {
@@ -79,7 +79,7 @@ class MoneyCommand : AbstractCommand("money", listOf("dinheiro", "grana"), Comma
 				val euroValueInCurrency = exchangeRates[from] ?: run {
 					context.reply(
                             LorittaReply(
-                                    message = locale["commands.utils.money.invalidCurrency"].msgFormat(from, exchangeRates.keys.joinToString(transform = { "`$it`" })),
+                                    message = locale["commands.command.money.invalidCurrency"].msgFormat(from, exchangeRates.keys.joinToString(transform = { "`$it`" })),
                                     prefix = Constants.ERROR
                             )
 					)
@@ -91,7 +91,7 @@ class MoneyCommand : AbstractCommand("money", listOf("dinheiro", "grana"), Comma
 				val endValueInEuros = exchangeRates[to] ?: run {
 					context.reply(
                             LorittaReply(
-                                    message = locale["commands.utils.money.invalidCurrency"].msgFormat(to, exchangeRates.keys.joinToString(transform = { "`$it`" })),
+                                    message = locale["commands.command.money.invalidCurrency"].msgFormat(to, exchangeRates.keys.joinToString(transform = { "`$it`" })),
                                     prefix = Constants.ERROR
                             )
 					)
@@ -106,7 +106,7 @@ class MoneyCommand : AbstractCommand("money", listOf("dinheiro", "grana"), Comma
 
 			context.reply(
                     LorittaReply(
-                            message = locale["commands.utils.money.converted", multiply, from, to, df.format(value * multiply)],
+                            message = locale["commands.command.money.converted", multiply, from, to, df.format(value * multiply)],
                             prefix = "\uD83D\uDCB5"
                     )
 			)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/MorseCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/MorseCommand.kt
@@ -14,8 +14,8 @@ import java.awt.Color
 class MorseCommand : AbstractCommand("morse", category = CommandCategory.UTILS) {
 	// TODO: Fix Usage
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.morse.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.utils.morse.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.morse.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.morse.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		if (context.args.isNotEmpty()) {
@@ -25,13 +25,13 @@ class MorseCommand : AbstractCommand("morse", category = CommandCategory.UTILS) 
 			val fromMorse = message.fromMorse()
 
 			if (toMorse.trim().isEmpty()) {
-				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + locale["commands.utils.morse.fail"])
+				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + locale["commands.command.morse.fail"])
 				return
 			}
 
 			val embed = EmbedBuilder()
 
-			embed.setTitle(if (fromMorse.isNotEmpty()) "\uD83D\uDC48\uD83D\uDCFB ${locale["commands.utils.morse.toFrom"]}" else "\uD83D\uDC49\uD83D\uDCFB ${locale["commands.utils.morse.fromTo"]}")
+			embed.setTitle(if (fromMorse.isNotEmpty()) "\uD83D\uDC48\uD83D\uDCFB ${locale["commands.command.morse.toFrom"]}" else "\uD83D\uDC49\uD83D\uDCFB ${locale["commands.command.morse.fromTo"]}")
 			embed.setDescription("*beep* *boop*```${if (fromMorse.isNotEmpty()) fromMorse else toMorse}```")
 			embed.setColor(Color(153, 170, 181))
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/OCRCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/OCRCommand.kt
@@ -22,7 +22,7 @@ import java.util.*
 import javax.imageio.ImageIO
 
 class OCRCommand : AbstractCommand("ocr", listOf("ler", "read"), CommandCategory.UTILS) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.ocr.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.ocr.description")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		val contextImage = context.getImageAt(0) ?: run { Constants.INVALID_IMAGE_REPLY.invoke(context); return; }
@@ -63,7 +63,7 @@ class OCRCommand : AbstractCommand("ocr", listOf("ler", "read"), CommandCategory
 			try {
 				builder.setDescription("```${parsedResponse["responses"][0]["textAnnotations"][0]["description"].string}```")
 			} catch (e: Exception) {
-				builder.setDescription("**${locale["commands.utils.ocr.couldntFind"]}**")
+				builder.setDescription("**${locale["commands.command.ocr.couldntFind"]}**")
 			}
 			context.sendMessage(context.getAsMention(true), builder.build())
 		}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/PackageInfoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/PackageInfoCommand.kt
@@ -18,7 +18,7 @@ import java.awt.Color
 import java.util.*
 
 class PackageInfoCommand : AbstractCommand("packageinfo", listOf("correios", "ctt"), CommandCategory.UTILS) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.packageinfo.description")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.packageinfo.description")
 
 	override fun getExamples(): List<String> {
 		return Arrays.asList("correios")
@@ -38,7 +38,7 @@ class PackageInfoCommand : AbstractCommand("packageinfo", listOf("correios", "ct
 				if (pair == null) {
 					context.reply(
 							LorittaReply(
-									message = locale["commands.utils.packageinfo.couldntFind", packageId],
+									message = locale["commands.command.packageinfo.couldntFind", packageId],
 									prefix = Constants.ERROR
 							)
 					)
@@ -67,7 +67,7 @@ class PackageInfoCommand : AbstractCommand("packageinfo", listOf("correios", "ct
 			} catch (e: Exception) {
 				context.reply(
 						LorittaReply(
-								message = locale["commands.utils.packageinfo.invalid", packageId],
+								message = locale["commands.command.packageinfo.invalid", packageId],
 								prefix = Constants.ERROR
 						)
 				)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/TempoCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/TempoCommand.kt
@@ -17,8 +17,8 @@ import java.net.URLEncoder
 class TempoCommand : AbstractCommand("weather", listOf("tempo", "previsão", "previsao"), CommandCategory.UTILS) {
 	// TODO: Fix Usage
 
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.weather.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.utils.weather.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.weather.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.weather.examples")
 
 	override suspend fun run(context: CommandContext,locale: BaseLocale) {
 		if (context.args.isNotEmpty()) {
@@ -73,18 +73,18 @@ class TempoCommand : AbstractCommand("weather", listOf("tempo", "previsão", "pr
 					icon = "\uD83C\uDF2B "
 				}
 
-				embed.setTitle(locale["commands.utils.weather.forecastFor", realCityName, countryShort])
+				embed.setTitle(locale["commands.command.weather.forecastFor", realCityName, countryShort])
 				embed.setDescription(icon + description)
 				embed.setColor(Color(0, 210, 255))
-				embed.addField("🌡 ${context.locale["commands.utils.weather.temperature"]}", "**${context.locale["commands.utils.weather.current"]}: **$now ºC\n**${context.locale["commands.utils.weather.max"]}: **$max ºC\n**${context.locale["commands.utils.weather.min"]}: **$min ºC", true)
-				embed.addField("💦 ${context.locale["commands.utils.weather.humidity"]}", "$humidity%", true)
-				embed.addField("🌬 ${context.locale["commands.utils.weather.windSpeed"]}", "$windSpeed km/h", true)
-				embed.addField("🏋 ${context.locale["commands.utils.weather.airPressure"]}", "$pressure kPA", true)
+				embed.addField("🌡 ${context.locale["commands.command.weather.temperature"]}", "**${context.locale["commands.command.weather.current"]}: **$now ºC\n**${context.locale["commands.command.weather.max"]}: **$max ºC\n**${context.locale["commands.command.weather.min"]}: **$min ºC", true)
+				embed.addField("💦 ${context.locale["commands.command.weather.humidity"]}", "$humidity%", true)
+				embed.addField("🌬 ${context.locale["commands.command.weather.windSpeed"]}", "$windSpeed km/h", true)
+				embed.addField("🏋 ${context.locale["commands.command.weather.airPressure"]}", "$pressure kPA", true)
 
 				context.sendMessage(embed.build())
 			} else {
 				// Cidade inexistente!
-				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.utils.weather.couldntFind", cidade])
+				context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + context.locale["commands.command.weather.couldntFind", cidade])
 			}
 		} else {
 			this.explain(context)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/TranslateCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/TranslateCommand.kt
@@ -10,8 +10,8 @@ import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
 
 class TranslateCommand : AbstractCommand("traduzir", listOf("translate"), CommandCategory.UTILS) {
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.translate.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.utils.translate.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.translate.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.translate.examples")
 
 	// TODO: Fix Usage
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/WikipediaCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/utils/WikipediaCommand.kt
@@ -21,8 +21,8 @@ class WikipediaCommand : AbstractCommand("wikipedia", listOf("wiki"), CommandCat
 				"en", "fr", "de", "es", "ja", "ru", "it", "zh", "pt", "ar", "fa", "pl", "nl", "id", "uk", "he", "sv", "cs", "ko", "vi", "ca", "no", "fi", "hu", "tr", "ro", "el", "th", "hi", "bn", "az", "simple", "ceb", "sw", "kk", "da", "eo", "sr", "lt", "sk", "bg", "sl", "eu", "et", "hr", "ms", "arz", "ur", "ta", "te", "nn", "gl", "af", "bs", "be", "ml", "ka", "is", "sq", "uz", "la", "mk", "lv", "azb", "mr", "sh", "tl", "cy", "sco", "ku", "ckb", "ast", "ba", "be-tarask", "zh-yue", "als", "ga", "hy", "pa", "my", "kn", "mn", "war", "zh-min-nan", "vo", "min", "lmo", "ht", "lb", "br", "gu", "tg", "new", "bpy", "nds", "io", "pms", "su", "oc", "jv", "nap", "scn", "wa", "bar", "an", "ksh", "szl", "fy", "frr", "ia", "yi", "mg", "gd", "vec", "ce", "sa", "mai", "xmf", "sd", "wuu", "as", "mrj", "mhr", "km", "roa-tara", "am", "roa-rup", "map-bms", "bh", "mnw", "shn", "bcl", "co", "cv", "dv", "nds-nl", "fo", "hif", "fur", "gan", "glk", "gu", "hak", "ilo", "pam", "csb", "avk", "lij", "li", "gv", "mi", "mt", "nah", "ne", "nrm", "se", "nov", "qu", "os", "pi", "pag", "ps", "pdc", "rm", "bat-smg", "sc", "si", "tt", "tk", "hsb", "fiu-vro", "vls", "yo", "diq", "zh-classical", "frp", "lad", "kw", "haw", "ang", "ln", "ie", "wo", "crh", "nv", "jbo", "ay", "pcd", "zea", "eml", "ky", "ig", "or", "cbk-zam", "kg", "arc", "rmy", "ab", "gn", "so", "kab", "ug", "stq", "ha", "udm", "ext", "mzn", "pap", "cu", "sah", "tet", "sn", "lo", "pnb", "iu", "na", "got", "bo", "dsb", "chr", "cdo", "om", "sm", "ee", "av", "bm", "zu", "cr", "pih", "ss", "bi", "rw", "ch", "xh", "kl", "ik", "bug", "ts", "kv", "xal", "st", "tw", "bxr", "ak", "ny", "lbe", "za", "ks", "ff", "lg", "chy", "mwl", "lez", "bjn", "gom", "lrc", "tyv", "vep", "nso", "kbd", "ltg", "rue", "pfl", "gag", "koi", "ace", "olo", "kaa", "mdf", "myv", "ady", "tcy", "dty", "atj", "kbp", "din", "lfn", "gor", "inh", "sat", "hyw", "nqo", "ban", "szy", "gcr", "ary", "lld", "smn", "to", "tpi", "ty", "ti", "pnt", "ve", "dz", "tn", "tum", "fj", "ki", "sg", "rn", "krc", "srn", "jam", "awa", "nostalgia",
 		)
 	}
-	override fun getDescriptionKey() = LocaleKeyData("commands.utils.wikipedia.description")
-	override fun getExamplesKey() = LocaleKeyData("commands.utils.wikipedia.examples")
+	override fun getDescriptionKey() = LocaleKeyData("commands.command.wikipedia.description")
+	override fun getExamplesKey() = LocaleKeyData("commands.command.wikipedia.examples")
 	// TODO: Fix Usage
 	// TODO: Fix Detailed Usage
 
@@ -46,7 +46,7 @@ class WikipediaCommand : AbstractCommand("wikipedia", listOf("wiki"), CommandCat
 					context.reply(
 							LorittaReply(
 									locale[
-											"commands.utils.wikipedia.invalidLanguage",
+											"commands.command.wikipedia.invalidLanguage",
 											VALID_WIKIPEDIAS.joinToString(", ", transform = { "`$it`" })
 									],
 									Constants.ERROR
@@ -67,7 +67,7 @@ class WikipediaCommand : AbstractCommand("wikipedia", listOf("wiki"), CommandCat
 				val entryWikiContent = wikiPages.entrySet().iterator().next() // Conteúdo
 
 				if (entryWikiContent.key == "-1") { // -1 = Nenhuma página encontrada
-					context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + locale["commands.utils.wikipedia.couldntFind", query])
+					context.sendMessage(Constants.ERROR + " **|** " + context.getAsMention(true) + locale["commands.command.wikipedia.couldntFind", query])
 				} else {
 					// Se não é -1, então é algo que existe! Yay!
 					val pageTitle = entryWikiContent.value.asJsonObject.get("title").asString

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/gifs/GumballGIF.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/gifs/GumballGIF.kt
@@ -73,7 +73,7 @@ object GumballGIF {
 				if (i in 0..27) {
 					ImageUtils.drawCenteredStringOutlined(
 							graphics,
-							locale["commands.images.gumballliftup.subtitle1"],
+							locale["commands.command.gumballliftup.subtitle1"],
 							subtitles,
 							font
 					)
@@ -81,7 +81,7 @@ object GumballGIF {
 				if (i in 28..45) {
 					ImageUtils.drawCenteredStringOutlined(
 							graphics,
-							locale["commands.images.gumballliftup.subtitle2"],
+							locale["commands.command.gumballliftup.subtitle2"],
 							subtitles,
 							font
 					)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/modules/AFKModule.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/modules/AFKModule.kt
@@ -39,7 +39,7 @@ class AFKModule : MessageReceivedModule {
 				event.channel.sendMessage(
 						LorittaReply(
                                 message = locale["loritta.modules.afk.userIsAfk", "**" + afkMembers[0].first.effectiveName.escapeMentions().stripCodeMarks() + "**"] + if (afkMembers[0].second != null) {
-                                    " **" + locale["commands.moderation.punishmentReason"] + "** » `${afkMembers[0].second}`"
+                                    " **" + locale["commands.category.moderation.punishmentReason"] + "** » `${afkMembers[0].second}`"
                                 } else {
                                     ""
                                 },

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/threads/RaffleThread.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/threads/RaffleThread.kt
@@ -112,8 +112,8 @@ class RaffleThread : Thread("Raffle Thread") {
 					val embed = EmbedBuilder()
 					embed.setThumbnail("attachment://loritta_money.png")
 					embed.setColor(Constants.LORITTA_AQUA)
-					embed.setTitle("\uD83C\uDF89 ${locale["commands.economy.raffle.congratulations"]}!")
-					embed.setDescription("${locale["commands.economy.raffle.youEarned", lastWinnerPrize]} \uD83E\uDD11")
+					embed.setTitle("\uD83C\uDF89 ${locale["commands.command.raffle.congratulations"]}!")
+					embed.setDescription("${locale["commands.command.raffle.youEarned", lastWinnerPrize]} \uD83E\uDD11")
 					embed.setTimestamp(Instant.now())
 					val message = MessageBuilder().setContent(" ").setEmbed(embed.build()).build()
 					user.openPrivateChannel().queue {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/threads/RemindersThread.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/threads/RemindersThread.kt
@@ -108,7 +108,7 @@ class RemindersThread : Thread("Reminders Thread") {
 				val month = String.format("%02d", calendar[Calendar.MONTH] + 1)
 				val hours = String.format("%02d", calendar[Calendar.HOUR_OF_DAY])
 				val minutes = String.format("%02d", calendar[Calendar.MINUTE])
-				val messageContent = loritta.getLocaleById("default")["commands.utils.remindme.success", dayOfMonth, month, calendar[Calendar.YEAR], hours, minutes]
+				val messageContent = loritta.getLocaleById("default")["commands.command.remindme.success", dayOfMonth, month, calendar[Calendar.YEAR], hours, minutes]
 
 				message.editMessage("<@${reminder.userId}> $messageContent").queue()
 				message.clearReactions().queue()
@@ -152,7 +152,7 @@ class RemindersThread : Thread("Reminders Thread") {
 			val month = String.format("%02d", calendar[Calendar.MONTH] + 1)
 			val hours = String.format("%02d", calendar[Calendar.HOUR_OF_DAY])
 			val minutes = String.format("%02d", calendar[Calendar.MINUTE])
-			val messageContent = loritta.getLocaleById("default")["commands.utils.remindme.success", dayOfMonth, month, calendar[Calendar.YEAR], hours, minutes]
+			val messageContent = loritta.getLocaleById("default")["commands.command.remindme.success", dayOfMonth, month, calendar[Calendar.YEAR], hours, minutes]
 
 			reply.channel.sendMessage("<@${reminder.userId}> $messageContent").queue()
 		}

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/utils/Jankenpon.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/utils/Jankenpon.kt
@@ -4,9 +4,9 @@ import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
 
 enum class Jankenpon(var lang: String, var emoji: String, var wins: String, var loses: String) {
 	// Os wins e os loses precisam ser uma string já que os enums ainda não foram inicializados
-	ROCK("commands.fun.rockpaperscissors.rock", "\uD83C\uDF11", "SCISSORS", "PAPER"),
-	PAPER("commands.fun.rockpaperscissors.paper", ":newspaper:", "ROCK", "SCISSORS"),
-	SCISSORS("commands.fun.rockpaperscissors.scissors", ":scissors:", "PAPER", "ROCK");
+	ROCK("commands.command.rockpaperscissors.rock", "\uD83C\uDF11", "SCISSORS", "PAPER"),
+	PAPER("commands.command.rockpaperscissors.paper", ":newspaper:", "ROCK", "SCISSORS"),
+	SCISSORS("commands.command.rockpaperscissors.scissors", ":scissors:", "PAPER", "ROCK");
 
 	fun getStatus(janken: Jankenpon): JankenponStatus {
 		if (this.name.equals(janken.loses, ignoreCase = true)) {

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/utils/LorittaUtilsKotlin.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/utils/LorittaUtilsKotlin.kt
@@ -140,7 +140,7 @@ object LorittaUtilsKotlin {
 					if (it != null)
 						DateUtils.formatMillis(it - System.currentTimeMillis(), locale)
 					else
-						locale["commands.moderation.mute.forever"]
+						locale["commands.command.mute.forever"]
 				},
 				loritta.instanceConfig.loritta.website.url + "support",
 				loritta.instanceConfig.loritta.website.url + "guidelines",

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/BanInfoCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/BanInfoCommand.kt
@@ -19,8 +19,8 @@ import net.perfectdreams.loritta.utils.Emotes
 
 class BanInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("baninfo", "infoban", "checkban"), CommandCategory.ADMIN) {
     override fun command() = create {
-        localizedDescription("commands.moderation.baninfo.description")
-        localizedExamples("commands.moderation.baninfo.examples")
+        localizedDescription("commands.command.baninfo.description")
+        localizedExamples("commands.command.baninfo.examples")
 
         arguments {
             argument(ArgumentType.USER) {
@@ -39,12 +39,12 @@ class BanInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(lorit
             
             try {
                 val banInformation = userId.let { guild.retrieveBanById(it.toLong()).await() }
-                val banReason = banInformation.reason ?: locale["commands.moderation.baninfo.noReasonSpecified"]
+                val banReason = banInformation.reason ?: locale["commands.command.baninfo.noReasonSpecified"]
                 val embed = EmbedBuilder()
-                        .setTitle("${Emotes.LORI_COFFEE} ${locale["commands.moderation.baninfo.title"]}")
+                        .setTitle("${Emotes.LORI_COFFEE} ${locale["commands.command.baninfo.title"]}")
                         .setThumbnail(banInformation.user.avatarUrl)
-                        .addField("${Emotes.LORI_TEMMIE} ${locale["commands.moderation.baninfo.user"]}", "`${banInformation.user.asTag}`", false)
-                        .addField("${Emotes.LORI_BAN_HAMMER} ${locale["commands.moderation.baninfo.reason"]}", "`${banReason}`", false)
+                        .addField("${Emotes.LORI_TEMMIE} ${locale["commands.command.baninfo.user"]}", "`${banInformation.user.asTag}`", false)
+                        .addField("${Emotes.LORI_BAN_HAMMER} ${locale["commands.command.baninfo.reason"]}", "`${banReason}`", false)
                         .setColor(Constants.DISCORD_BLURPLE)
                         .setFooter("Se você deseja desbanir este usuário, aperte no ⚒️!")
                 discordMessage.channel.sendMessage(embed.build()).await().also {
@@ -54,7 +54,7 @@ class BanInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(lorit
                         guild.unban(userId).queue()
                         reply(
                                 LorittaReply(
-                                        locale["commands.moderation.unban.successfullyUnbanned"],
+                                        locale["commands.command.unban.successfullyUnbanned"],
                                         Emotes.LORI_BAN_HAMMER
                                 )
                         )
@@ -64,7 +64,7 @@ class BanInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(lorit
 
             } catch (e: ErrorResponseException) {
                 if (e.errorResponse == ErrorResponse.UNKNOWN_BAN)
-                    fail(locale["commands.moderation.baninfo.banDoesNotExist"])
+                    fail(locale["commands.command.baninfo.banDoesNotExist"])
                 throw e
             }
         }

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/BanInfoCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/BanInfoCommand.kt
@@ -17,7 +17,7 @@ import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 import net.perfectdreams.loritta.utils.Emotes
 
-class BanInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("baninfo", "infoban", "checkban"), CommandCategory.ADMIN) {
+class BanInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("baninfo", "infoban", "checkban"), CommandCategory.MODERATION) {
     override fun command() = create {
         localizedDescription("commands.command.baninfo.description")
         localizedExamples("commands.command.baninfo.examples")

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
@@ -21,7 +21,7 @@ import net.perfectdreams.loritta.utils.sendStyledReply
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("clean", "limpar", "clear"), CommandCategory.ADMIN) {
+class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("clean", "limpar", "clear"), CommandCategory.MODERATION) {
 
     override fun command(): Command<CommandContext> = create {
         localizedDescription("commands.command.clear.description")

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/administration/ClearCommand.kt
@@ -24,8 +24,8 @@ import java.util.concurrent.TimeUnit
 class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("clean", "limpar", "clear"), CommandCategory.ADMIN) {
 
     override fun command(): Command<CommandContext> = create {
-        localizedDescription("commands.moderation.clear.description")
-        localizedExamples("commands.moderation.clear.examples")
+        localizedDescription("commands.command.clear.description")
+        localizedExamples("commands.command.clear.examples")
 
         userRequiredPermissions = listOf(Permission.MESSAGE_MANAGE)
         botRequiredPermissions = listOf(Permission.MESSAGE_MANAGE, Permission.MESSAGE_HISTORY)
@@ -47,19 +47,19 @@ class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta,
 
             // The message count can't be null or be higher than 500 and lower than 2
             if (count == null || count !in 2..MAX_RANGE)
-                fail(locale["commands.moderation.clear.invalidClearRange"], Constants.ERROR)
+                fail(locale["commands.command.clear.invalidClearRange"], Constants.ERROR)
 
             // If the guild already have a clear operation queued, we'll prevent them from creating another one
             if (unavailableGuilds.contains(guild.idLong))
-                fail(locale["commands.moderation.clear.operationQueued"], Constants.ERROR)
+                fail(locale["commands.command.clear.operationQueued"], Constants.ERROR)
 
             // The filter text and target user, null if not available
             val (targets, text, textInserted) = getOptions()
 
             if (targets.filterNotNull().isEmpty() && targets.isNotEmpty())
-                fail(locale["commands.moderation.clear.invalidUserFilter"], Constants.ERROR)
+                fail(locale["commands.command.clear.invalidUserFilter"], Constants.ERROR)
             if (text == null && textInserted)
-                fail(locale["commands.moderation.clear.invalidTextFilter"], Constants.ERROR)
+                fail(locale["commands.command.clear.invalidTextFilter"], Constants.ERROR)
 
             // Deleting the user's message (the command one, +clear)
             runCatching {
@@ -74,7 +74,7 @@ class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta,
             val disallowedMessages = messages.minus(allowedMessages)
 
             if (allowedMessages.isEmpty()) // If there are no allowed messages, we'll cancel the execution
-                fail(locale["commands.moderation.clear.couldNotFindMessages"], Constants.ERROR)
+                fail(locale["commands.command.clear.couldNotFindMessages"], Constants.ERROR)
 
             // Clear the messages after deleting the command's one3
             clear(allowedMessages)
@@ -82,12 +82,12 @@ class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta,
             sendStyledReply {
                 append {
                     prefix = "\uD83C\uDF89"
-                    message = locale["commands.moderation.clear.success", allowedMessages.size, user.asMention]
+                    message = locale["commands.command.clear.success", allowedMessages.size, user.asMention]
                 }
 
                 appendIf(disallowedMessages.isNotEmpty()) {
                     prefix = "\uD83D\uDD37"
-                    message = locale["commands.moderation.clear.successButIgnoredMessages", disallowedMessages.size]
+                    message = locale["commands.command.clear.successButIgnoredMessages", disallowedMessages.size]
                 }
             }
         }
@@ -118,7 +118,7 @@ class ClearCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta,
      * @return Command options
      */
     private suspend fun DiscordCommandContext.getOptions(): CommandOptions {
-        val optionName = locale["commands.moderation.clear.targetOption"]
+        val optionName = locale["commands.command.clear.targetOption"]
         val options = args.drop(1).joinToString(" ").trim().split("$optionName:")
 
         var text: String? = options.firstOrNull()

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/economy/SonhosTopCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/economy/SonhosTopCommand.kt
@@ -13,7 +13,7 @@ import org.jetbrains.exposed.sql.selectAll
 
 class SonhosTopCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("sonhos top", "atm top"), CommandCategory.ECONOMY) {
 	override fun command() = create {
-		localizedDescription("commands.economy.sonhostop.description")
+		localizedDescription("commands.command.sonhostop.description")
 
 		executesDiscord {
 			var page = args.getOrNull(0)?.toLongOrNull()

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/economy/SonhosTopLocalCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/economy/SonhosTopLocalCommand.kt
@@ -13,7 +13,7 @@ import org.jetbrains.exposed.sql.*
 
 class SonhosTopLocalCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("sonhos top local", "atm top local"), CommandCategory.ECONOMY) {
 	override fun command() = create {
-		localizedDescription("commands.economy.sonhostoplocal.description")
+		localizedDescription("commands.command.sonhostoplocal.description")
 
 		executesDiscord {
 			var page = args.getOrNull(0)?.toLongOrNull()

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/economy/TransactionsCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/economy/TransactionsCommand.kt
@@ -26,7 +26,7 @@ import java.time.ZoneId
 
 class TransactionsCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("transactions", "transações", "transacoes", "transaçoes"), CommandCategory.ECONOMY) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.economy.transactions"
+		private const val LOCALE_PREFIX = "commands.command.transactions"
 		private const val ENTRIES_PER_PAGE = 10
 	}
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/FanArtsCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/FanArtsCommand.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 class FanArtsCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("fanarts", "fanart"), CommandCategory.MISC) {
     override fun command() = create {
-        localizedDescription("commands.misc.fanArts.description", "<a:lori_blobheartseyes:393914347706908683>", "<a:lori_blobheartseyes:393914347706908683>")
+        localizedDescription("commands.command.fanarts.description", "<a:lori_blobheartseyes:393914347706908683>", "<a:lori_blobheartseyes:393914347706908683>")
 
         arguments {
             argument(ArgumentType.NUMBER) {
@@ -64,7 +64,7 @@ class FanArtsCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(lorit
 
             val displayName = fanArtArtist?.info?.override?.name ?: user?.name ?: fanArtArtist?.info?.name
 
-            setDescription("**" + locale["commands.misc.fanArts.madeBy", displayName] + "**")
+            setDescription("**" + locale["commands.command.fanarts.madeBy", displayName] + "**")
 
             // TODO: Corrigir
             /* if (artist != null) {
@@ -77,7 +77,7 @@ class FanArtsCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(lorit
                 }
             } */
 
-            appendDescription("\n\n${locale["commands.misc.fanArts.thankYouAll", displayName]}")
+            appendDescription("\n\n${locale["commands.command.fanarts.thankYouAll", displayName]}")
 
             var footer = "Fan Art ${locale["loritta.xOfX", index, LorittaLauncher.loritta.fanArts.size]}"
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/GiveawayCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/GiveawayCommand.kt
@@ -9,7 +9,7 @@ import java.awt.Color
 
 class GiveawayCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("giveaway", "sorteio"), CommandCategory.FUN) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.fun"
+		private const val LOCALE_PREFIX = "commands.command"
 	}
 
 	override fun command() = create {
@@ -23,9 +23,9 @@ class GiveawayCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(lori
 			val context = this
 
 			val embed = EmbedBuilder()
-					.setTitle("\uD83C\uDF89 ${locale["commands.fun.giveawaymenu.categoryTitle"]}")
+					.setTitle("\uD83C\uDF89 ${locale["commands.command.giveawaymenu.categoryTitle"]}")
 					.setThumbnail("https://loritta.website/assets/img/loritta_confetti.png")
-					.setDescription("*${locale["commands.fun.giveawaymenu.categoryDescription"]}*\n\n")
+					.setDescription("*${locale["commands.command.giveawaymenu.categoryDescription"]}*\n\n")
 					.setColor(Color(200, 20, 217))
 
 			val commands = listOf(

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/GiveawayEndCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/GiveawayEndCommand.kt
@@ -17,7 +17,7 @@ import org.jetbrains.exposed.sql.and
 
 class GiveawayEndCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("giveaway end", "sorteio end"), CommandCategory.FUN) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.fun"
+		private const val LOCALE_PREFIX = "commands.command"
 	}
 
 	override fun command() = create {

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/GiveawayRerollCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/GiveawayRerollCommand.kt
@@ -17,7 +17,7 @@ import org.jetbrains.exposed.sql.and
 
 class GiveawayRerollCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("giveaway reroll", "sorteio reroll"), CommandCategory.FUN) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.fun"
+		private const val LOCALE_PREFIX = "commands.command"
 	}
 
 	override fun command() = create {

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/GiveawaySetupCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/fun/GiveawaySetupCommand.kt
@@ -20,7 +20,7 @@ import net.perfectdreams.loritta.utils.giveaway.GiveawayManager
 
 class GiveawaySetupCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("giveaway setup", "sorteio setup", "giveaway criar", "sorteio criar", "giveaway create", "sorteio create"), CommandCategory.FUN) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.fun"
+        private const val LOCALE_PREFIX = "commands.command"
         val logger = KotlinLogging.logger { }
     }
 
@@ -50,7 +50,7 @@ class GiveawaySetupCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(
                 if (message != null) {
                     context.reply(
                             LorittaReply(
-                                    message = locale["commands.fun.giveaway.giveawayValidCustomMessage"],
+                                    message = locale["commands.command.giveaway.giveawayValidCustomMessage"],
                                     prefix = Emotes.LORI_TEMMIE
                             )
                     )
@@ -112,7 +112,7 @@ class GiveawaySetupCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(
     suspend fun getGiveawayDuration(context: DiscordCommandContext, locale: BaseLocale, builder: GiveawayBuilder) {
         val message = context.discordMessage.channel.sendMessage(
                 LorittaReply(
-                        message = locale["commands.fun.giveaway.giveawayDuration"],
+                        message = locale["commands.command.giveaway.giveawayDuration"],
                         prefix = "\uD83E\uDD14"
                 ).build(context.getUserMention(true))
         ).await()
@@ -296,7 +296,7 @@ class GiveawaySetupCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(
                     if (roles.isEmpty()) {
                         context.reply(
                                 LorittaReply(
-                                        locale["commands.fun.giveaway.giveawayNoValidRoles"],
+                                        locale["commands.command.giveaway.giveawayNoValidRoles"],
                                         Constants.ERROR
                                 )
                         )
@@ -307,7 +307,7 @@ class GiveawaySetupCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(
                         if (!context.guild.selfMember.canInteract(role) || role.isManaged) {
                             context.reply(
                                     LorittaReply(
-                                            locale["commands.fun.giveaway.giveawayCantInteractWithRole", "`${role.name}`"],
+                                            locale["commands.command.giveaway.giveawayCantInteractWithRole", "`${role.name}`"],
                                             Constants.ERROR
                                     )
                             )
@@ -317,7 +317,7 @@ class GiveawaySetupCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(
                         if (context.discordMessage.member?.canInteract(role) == false) {
                             context.reply(
                                     LorittaReply(
-                                            locale["commands.fun.giveaway.giveawayCantYouInteractWithRole", "`${role.name}`"],
+                                            locale["commands.command.giveaway.giveawayCantYouInteractWithRole", "`${role.name}`"],
                                             Constants.ERROR
                                     )
                             )
@@ -340,7 +340,7 @@ class GiveawaySetupCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(
     suspend fun getGiveawayWinnerCount(context: DiscordCommandContext, locale: BaseLocale, builder: GiveawayBuilder) {
         val message = context.discordMessage.channel.sendMessage(
                 LorittaReply(
-                        message = locale["commands.fun.giveaway.giveawayWinnerCount"],
+                        message = locale["commands.command.giveaway.giveawayWinnerCount"],
                         prefix = "\uD83E\uDD14"
                 ).build(context.getUserMention(true))
         ).await()
@@ -363,7 +363,7 @@ class GiveawaySetupCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(
             if (numberOfWinners !in 1..100) {
                 context.reply(
                         LorittaReply(
-                                locale["commands.fun.giveaway.giveawayWinnerCountNotInRange"],
+                                locale["commands.command.giveaway.giveawayWinnerCountNotInRange"],
                                 Constants.ERROR
                         )
                 )

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/roblox/RbGameCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/roblox/RbGameCommand.kt
@@ -19,7 +19,7 @@ import java.time.format.DateTimeFormatter
 
 class RbGameCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("rbgame", "rbjogo", "rbgameinfo"), CommandCategory.ROBLOX) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.roblox.rbgame"
+        private const val LOCALE_PREFIX = "commands.command.rbgame"
     }
 
     override fun command() = create {
@@ -93,12 +93,12 @@ class RbGameCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta
                 val downvotes = voteSection.attr("data-total-down-votes")
 
                 embed.setTitle("<:roblox_logo:412576693803286528> $gameName", gameUrl)
-                embed.addField("\uD83D\uDCBB ${locale["commands.roblox.rbuser.robloxId"]}", placeId, true)
+                embed.addField("\uD83D\uDCBB ${locale["commands.command.rbuser.robloxId"]}", placeId, true)
                 embed.addField("<:starstruck:540988091117076481> ${locale["$LOCALE_PREFIX.favorites"]}", favoriteCount, true)
                 embed.addField("\uD83D\uDC4D ${locale["$LOCALE_PREFIX.likes"]}", upvotes, true)
                 embed.addField("\uD83D\uDC4E ${locale["$LOCALE_PREFIX.dislikes"]}", downvotes, true)
                 embed.addField("\uD83C\uDFAE ${locale["$LOCALE_PREFIX.playing"]}", playing, true)
-                embed.addField("\uD83D\uDC3E ${locale["commands.roblox.rbuser.visits"]}", visits, true)
+                embed.addField("\uD83D\uDC3E ${locale["commands.command.rbuser.visits"]}", visits, true)
                 embed.addField("\uD83C\uDF1F ${locale["$LOCALE_PREFIX.createdAt"]}", created, true)
                 embed.addField("✨ ${locale["$LOCALE_PREFIX.lastUpdated"]}", updated, true)
                 embed.addField("⛔ ${locale["$LOCALE_PREFIX.maxPlayers"]}", maxplayers, true)

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/roblox/RbUserCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/roblox/RbUserCommand.kt
@@ -32,7 +32,7 @@ import java.time.format.DateTimeFormatter
 
 class RbUserCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta,listOf("rbuser", "rbplayer"), CommandCategory.ROBLOX) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.roblox.rbuser"
+        private const val LOCALE_PREFIX = "commands.command.rbuser"
 
         // Example data: {"description":"####### ######## ####################################################### Brasil!","created":"2013-01-22T11:00:23.88Z","isBanned":false,"id":37271405,"name":"SonicteamPower","displayName":"SonicteamPower"}
         @Serializable

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/BomDiaECiaTopCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/BomDiaECiaTopCommand.kt
@@ -16,7 +16,7 @@ import org.jetbrains.exposed.sql.selectAll
 
 class BomDiaECiaTopCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("bomdiaecia top", "bd&c top", "bdc top"), CommandCategory.SOCIAL) {
 	override fun command() = create {
-		localizedDescription("commands.social.bomdiaeciatop.description")
+		localizedDescription("commands.command.bomdiaeciatop.description")
 
 		arguments {
 			argument(ArgumentType.NUMBER) {
@@ -63,7 +63,7 @@ class BomDiaECiaTopCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase
 									userData.map {
 										RankingGenerator.UserRankInformation(
 												it[userId],
-												locale["commands.social.bomdiaeciatop.wonMatches", it[userIdCount]]
+												locale["commands.command.bomdiaeciatop.wonMatches", it[userIdCount]]
 										)
 									}
 							)

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/BomDiaECiaTopLocalCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/BomDiaECiaTopLocalCommand.kt
@@ -17,7 +17,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 
 class BomDiaECiaTopLocalCommand(loritta: LorittaDiscord): DiscordAbstractCommandBase(loritta, listOf("bomdiaecia top local", "bd&c top local", "bdc top local"), CommandCategory.SOCIAL) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.social.bomdiaeciatoplocal"
+        private const val LOCALE_PREFIX = "commands.command.bomdiaeciatoplocal"
     }
     override fun command() = create {
         localizedDescription("$LOCALE_PREFIX.description")
@@ -70,7 +70,7 @@ class BomDiaECiaTopLocalCommand(loritta: LorittaDiscord): DiscordAbstractCommand
                         userData.map {
                             RankingGenerator.UserRankInformation(
                                 it[userId],
-                                locale["commands.social.bomdiaeciatop.wonMatches", it[userIdCount]]
+                                locale["commands.command.bomdiaeciatop.wonMatches", it[userIdCount]]
                             )
                         }
                     )

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/RankGlobalCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/RankGlobalCommand.kt
@@ -16,7 +16,7 @@ import org.jetbrains.exposed.sql.selectAll
 
 class RankGlobalCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("rank global", "top global", "leaderboard global", "ranking global"), CommandCategory.SOCIAL) {
 	override fun command() = create {
-		localizedDescription("commands.social.rankglobal.description")
+		localizedDescription("commands.command.rankglobal.description")
 
 		arguments {
 			argument(ArgumentType.NUMBER) {

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/RepTopCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/RepTopCommand.kt
@@ -16,7 +16,7 @@ import org.jetbrains.exposed.sql.selectAll
 
 class RepTopCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("rep top", "reputation top", "reputacao top", "reputação top"), CommandCategory.SOCIAL) {
 	override fun command() = create {
-		localizedDescription("commands.social.topreputation.description")
+		localizedDescription("commands.command.topreputation.description")
 
 		// TODO: Fix Examples
 		/* examples {
@@ -39,16 +39,16 @@ class RepTopCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritt
 			if (typeName == null) {
 				reply(
 						LorittaReply(
-								"${serverConfig.commandPrefix}${executedCommandLabel} ${locale["commands.social.topreputation.received"]}"
+								"${serverConfig.commandPrefix}${executedCommandLabel} ${locale["commands.command.topreputation.received"]}"
 						),
 						LorittaReply(
-								"${serverConfig.commandPrefix}${executedCommandLabel} ${locale["commands.social.topreputation.given"]}"
+								"${serverConfig.commandPrefix}${executedCommandLabel} ${locale["commands.command.topreputation.given"]}"
 						)
 				)
 				return@executesDiscord
 			}
 
-			val type = if (typeName in loritta.locales.map { locale["commands.social.topreputation.given"].toLowerCase() }.distinct())
+			val type = if (typeName in loritta.locales.map { locale["commands.command.topreputation.given"].toLowerCase() }.distinct())
 				TopOrder.MOST_GIVEN
 			else
 				TopOrder.MOST_RECEIVED
@@ -103,12 +103,12 @@ class RepTopCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritt
 										if (type == TopOrder.MOST_RECEIVED) {
 											RankingGenerator.UserRankInformation(
 													it[receivedBy],
-													locale["commands.social.topreputation.receivedReputations", it[receivedByCount]]
+													locale["commands.command.topreputation.receivedReputations", it[receivedByCount]]
 											)
 										} else {
 											RankingGenerator.UserRankInformation(
 													it[givenBy],
-													locale["commands.social.topreputation.givenReputations", it[givenByCount]]
+													locale["commands.command.topreputation.givenReputations", it[givenByCount]]
 											)
 										}
 									}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/XpNotificationsCommand.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/commands/vanilla/social/XpNotificationsCommand.kt
@@ -10,7 +10,7 @@ import net.perfectdreams.loritta.utils.Emotes
 
 class XpNotificationsCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("xpnotifications"), CommandCategory.SOCIAL) {
 	override fun command() = create {
-		localizedDescription("commands.social.xpnotifications.description")
+		localizedDescription("commands.command.xpnotifications.description")
 
 		arguments {
 			argument(ArgumentType.NUMBER) {
@@ -28,14 +28,14 @@ class XpNotificationsCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBa
 			if (newValue) {
 				reply(
 						LorittaReply(
-								locale["commands.social.xpnotifications.disabledNotifications"],
+								locale["commands.command.xpnotifications.disabledNotifications"],
 								Emotes.LORI_SMILE
 						)
 				)
 			} else {
 				reply(
 						LorittaReply(
-								locale["commands.social.xpnotifications.enabledNotifications"],
+								locale["commands.command.xpnotifications.enabledNotifications"],
 								Emotes.LORI_SMILE
 						)
 				)

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
@@ -31,8 +31,8 @@ import net.perfectdreams.loritta.commands.vanilla.`fun`.*
 import net.perfectdreams.loritta.commands.vanilla.administration.*
 import net.perfectdreams.loritta.commands.vanilla.economy.*
 import net.perfectdreams.loritta.commands.vanilla.magic.*
-import net.perfectdreams.loritta.commands.vanilla.social.*
 import net.perfectdreams.loritta.commands.vanilla.roblox.*
+import net.perfectdreams.loritta.commands.vanilla.social.*
 import net.perfectdreams.loritta.dao.Payment
 import net.perfectdreams.loritta.platform.discord.commands.DiscordCommandMap
 import net.perfectdreams.loritta.platform.discord.plugin.JVMPluginManager
@@ -328,35 +328,89 @@ abstract class LorittaDiscord(var discordConfig: GeneralDiscordConfig, var disco
         val singleQuotesWithoutSlashPrecedingItRegex = Regex("(?<!(?:\\\\))'")
 
         if (localeFolder.exists()) {
-            localeFolder.listFiles().filter { it.extension == "yml" || it.extension == "json" }.forEach {
-                val entries = Constants.YAML.load<MutableMap<String, Any?>>(it.readText())
+            fun loadFromFolder(folder: File, keyPrefix: (File) -> (String) = { "" }) {
+                folder.listFiles().filter { it.extension == "yml" || it.extension == "json" }.forEach {
+                    val entries = Constants.YAML.load<MutableMap<String, Any?>>(it.readText())
 
-                fun transformIntoFlatMap(map: MutableMap<String, Any?>, prefix: String) {
-                    map.forEach { (key, value) ->
-                        if (value is Map<*, *>) {
-                            transformIntoFlatMap(value as MutableMap<String, Any?>, "$prefix$key.")
-                        } else {
-                            if (value is List<*>) {
-                                locale.localeListEntries[prefix + key] = try {
-                                    (value as List<String>).map {
-                                        it.replace(singleQuotesWithoutSlashPrecedingItRegex, "''") // Escape single quotes
-                                                .replace("\\'", "'") // Replace \' with '
+                    fun transformIntoFlatMap(map: MutableMap<String, Any?>, prefix: String) {
+                        map.forEach { (key, value) ->
+                            if (value is Map<*, *>) {
+                                transformIntoFlatMap(value as MutableMap<String, Any?>, "${keyPrefix.invoke(it)}$prefix$key.")
+                            } else {
+                                if (value is List<*>) {
+                                    locale.localeListEntries[prefix + key] = try {
+                                        (value as List<String>).map {
+                                            it.replace(singleQuotesWithoutSlashPrecedingItRegex, "''") // Escape single quotes
+                                                    .replace("\\'", "'") // Replace \' with '
+                                        }
+                                    } catch (e: ClassCastException) {
+                                        // A LinkedHashMap does match the "is List<*>" check, but it fails when we cast the subtype to String
+                                        // If that happens, we will just ignore the exception and use the raw "value" list.
+                                        (value as List<String>)
                                     }
-                                } catch (e: ClassCastException) {
-                                    // A LinkedHashMap does match the "is List<*>" check, but it fails when we cast the subtype to String
-                                    // If that happens, we will just ignore the exception and use the raw "value" list.
-                                    (value as List<String>)
-                                }
-                            } else if (value is String) {
-                                locale.localeStringEntries[prefix + key] = value.replace(singleQuotesWithoutSlashPrecedingItRegex, "''") // Escape single quotes
-                                        .replace("\\'", "'") // Replace \' with '
-                            } else throw IllegalArgumentException("Invalid object type detected in YAML! $value")
+                                } else if (value is String) {
+                                    locale.localeStringEntries[keyPrefix.invoke(it) + prefix + key] = value.replace(singleQuotesWithoutSlashPrecedingItRegex, "''") // Escape single quotes
+                                            .replace("\\'", "'") // Replace \' with '
+                                } else throw IllegalArgumentException("Invalid object type detected in YAML! $value")
+                            }
                         }
                     }
-                }
 
-                transformIntoFlatMap(entries, "")
+                    transformIntoFlatMap(entries, "")
+                }
             }
+
+            loadFromFolder(localeFolder)
+
+            // Before, all commands locales were split up into different files, based on the category, example:
+            // commands-discord.yml
+            // commands:
+            //   discord:
+            //     userinfo:
+            //       description: "owo"
+            //
+            // However, this had a issue that, if we wanted to move commands from a category to another, we would need to move the locales from
+            // the file AND change the locale key, so, if we wanted to change a command category, that would also need to change all locale keys
+            // to match. I think that was not a great thing to have.
+            //
+            // I thought that maybe we could remove the category from the command itself and keep it as "command:" or something, like this:
+            // commands-discord.yml
+            // commands:
+            //   command:
+            //     userinfo:
+            //       description: "owo"
+            //
+            // This avoids the issue of needing to change the locale keys in the source code, but we still need to move stuff around if a category changes!
+            // (due to the file name)
+            // This also has a issue that Crowdin "forgets" who did the translation because the file changed, which is very undesirable.
+            //
+            // I thought that all the command keys could be in the same file and, while that would work, it would become a mess.
+            //
+            // So I decided to spice things up and split every command locale into different files, so, as an example:
+            // userinfo.yml
+            // commands:
+            //   discord:
+            //     userinfo:
+            //       description: "owo"
+            //
+            // But that's boring, let's spice it up even more!
+            // userinfo.yml
+            // description: "owo"
+            //
+            // And, when loading the file, the prefix "commands.command.FileNameHere." is automatically appended to the key!
+            // This fixes our previous issues:
+            // * No need to change the source code on category changes, because the locale key doesn't has any category related stuff
+            // * No need to change locales to other files due to category changes
+            // * More tidy
+            // * If a command is removed from Loritta, removing the locales is a breeze because you just need to delete the locale key related to the command!
+            //
+            // Very nice :3
+            //
+            // So, first, we will check if the commands folder exist and, if it is, we are going to load all the files within the folder and apply a
+            // auto prefix to it.
+            val commandsLocaleFolder = File(localeFolder, "commands")
+            if (commandsLocaleFolder.exists())
+                loadFromFolder(commandsLocaleFolder) { "commands.command.${it.nameWithoutExtension}." }
         }
 
         // Before we say "okay everything is OK! Let's go!!" we are going to format every single string on the locale

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/platform/discord/LorittaDiscord.kt
@@ -338,7 +338,7 @@ abstract class LorittaDiscord(var discordConfig: GeneralDiscordConfig, var disco
                                 transformIntoFlatMap(value as MutableMap<String, Any?>, "${keyPrefix.invoke(it)}$prefix$key.")
                             } else {
                                 if (value is List<*>) {
-                                    locale.localeListEntries[prefix + key] = try {
+                                    locale.localeListEntries[keyPrefix.invoke(it) +prefix + key] = try {
                                         (value as List<String>).map {
                                             it.replace(singleQuotesWithoutSlashPrecedingItRegex, "''") // Escape single quotes
                                                     .replace("\\'", "'") // Replace \' with '

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/giveaway/GiveawayManager.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/giveaway/GiveawayManager.kt
@@ -367,7 +367,7 @@ object GiveawayManager {
                     .await()
 
             if (users.size == 1 && users[0].id == loritta.discordConfig.discord.clientId) { // Ninguém participou do giveaway! (Só a Lori, mas ela não conta)
-                message.channel.sendMessageAsync("\uD83C\uDF89 **|** ${locale["commands.fun.giveaway.noWinner"]} ${Emotes.LORI_TEMMIE}")
+                message.channel.sendMessageAsync("\uD83C\uDF89 **|** ${locale["commands.command.giveaway.noWinner"]} ${Emotes.LORI_TEMMIE}")
             } else {
                 val winners = mutableListOf<User>()
                 val reactedUsers = users
@@ -397,10 +397,10 @@ object GiveawayManager {
                     val winner = winners.first()
                     messageBuilder
                         .setAllowedMentions(listOf(Message.MentionType.USER, Message.MentionType.CHANNEL, Message.MentionType.EMOTE))
-                        .setContent("\uD83C\uDF89 **|** ${locale["commands.fun.giveaway.oneWinner", winner.asMention, "**${giveaway.reason}**"]} ${Emotes.LORI_HAPPY}")
+                        .setContent("\uD83C\uDF89 **|** ${locale["commands.command.giveaway.oneWinner", winner.asMention, "**${giveaway.reason}**"]} ${Emotes.LORI_HAPPY}")
                     message.channel.sendMessageAsync(messageBuilder.build())
                 } else { // Mais de um ganhador
-                    val replies = mutableListOf("\uD83C\uDF89 **|** ${locale["commands.fun.giveaway.multipleWinners", "**${giveaway.reason}**"]} ${Emotes.LORI_HAPPY}")
+                    val replies = mutableListOf("\uD83C\uDF89 **|** ${locale["commands.command.giveaway.multipleWinners", "**${giveaway.reason}**"]} ${Emotes.LORI_HAPPY}")
 
                     repeat(giveaway.numberOfWinners) {
                         val user = winners.getOrNull(it)
@@ -450,7 +450,7 @@ object GiveawayManager {
         val embed = EmbedBuilder().apply {
             setTitle("\uD83C\uDF81 ${giveaway.reason}")
             setDescription(giveaway.description)
-            setFooter(locale["commands.fun.giveaway.giveawayEnded"], null)
+            setFooter(locale["commands.command.giveaway.giveawayEnded"], null)
         }
 
         message.editMessage(embed.build()).await()

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/locale/DebugLocales.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/locale/DebugLocales.kt
@@ -5,7 +5,7 @@ import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
 object DebugLocales {
     private val doNotChangeThisKeys = listOf(
             "loritta.inheritsFromLanguageId",
-            "commands.fortnite.shop.localeId",
+            "commands.command.shop.localeId",
             "website.localePath"
     )
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/user/PostUserReputationsRoute.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/user/PostUserReputationsRoute.kt
@@ -108,7 +108,7 @@ class PostUserReputationsRoute(loritta: LorittaDiscord) : RequiresAPIDiscordLogi
 					// Tudo certo? Então vamos enviar!
 					val reply = LorittaReply(
                             locale[
-                                    "commands.social.reputation.success",
+                                    "commands.command.reputation.success",
                                     "<@${giverId}>",
                                     "<@$receiverId>",
                                     reputationCount,

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/ActionCommands.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/ActionCommands.kt
@@ -37,7 +37,7 @@ abstract class ActionCommand(loritta: LorittaDiscord, labels: List<String>): Dis
     override fun command(): Command<CommandContext> = create {
         create().also {
             localizedDescription(it.description)
-            localizedExamples("commands.actions.examples")
+            localizedExamples("commands.category.action.examples")
 
             usage {
                 argument(ArgumentType.USER) {
@@ -56,7 +56,7 @@ abstract class ActionCommand(loritta: LorittaDiscord, labels: List<String>): Dis
 
 class ActionCommandDSL(val command: ActionCommand) {
 
-    var description: String = "commands.actions.${command.labels.first()}.description"
+    var description: String = "commands.command.${command.labels.first()}.description"
     var folderName: String? = command.labels.first()
 
     lateinit var color: Color
@@ -149,7 +149,7 @@ private suspend fun ActionCommandDSL.handle(context: DiscordCommandContext, send
                     .setImage(context.loritta.instanceConfig.loritta.website.url + "assets/img/actions/$folderName/${randomImage.folderName}/${randomImage.fileName}")
                     .also {
                         if (sender != receiver && !repeat) {
-                            it.setFooter(context.locale["commands.actions.clickToRetribute", "\uD83D\uDD01"], null)
+                            it.setFooter(context.locale["commands.category.anime.clickToRetribute", "\uD83D\uDD01"], null)
                         }
                     }
                     .build()
@@ -177,7 +177,7 @@ private fun DiscordCommandContext.addReactionButton(dsl: ActionCommandDSL, messa
 
 private suspend fun DiscordCommandContext.addIdiotReply() = reply(
         LorittaReply(
-                locale["commands.actions.kiss.responseAntiIdiot"],
+                locale["commands.command.kiss.responseAntiIdiot"],
                 "\uD83D\uDE45"
         )
 )

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/AttackCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/AttackCommand.kt
@@ -15,9 +15,9 @@ class AttackCommand(loritta: LorittaDiscord): ActionCommand(loritta, listOf("att
 
         response { locale, sender, target ->
             if (target.id != LorittaLauncher.loritta.discordConfig.discord.clientId) {
-                locale["commands.actions.attack.response", sender.asMention, target.asMention]
+                locale["commands.command.attack.response", sender.asMention, target.asMention]
             } else {
-                locale["commands.actions.attack.responseAntiIdiot", sender.asMention, target.asMention]
+                locale["commands.command.attack.responseAntiIdiot", sender.asMention, target.asMention]
             }
         }
     }

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/DanceCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/DanceCommand.kt
@@ -13,7 +13,7 @@ class DanceCommand(loritta: LorittaDiscord): ActionCommand(loritta, listOf("danc
         color = Color(255, 152, 0)
 
         response { locale, sender, target ->
-            locale["commands.actions.dance.response", sender.asMention, target.asMention]
+            locale["commands.command.dance.response", sender.asMention, target.asMention]
         }
     }
 

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/HeadPatCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/HeadPatCommand.kt
@@ -14,7 +14,7 @@ class HeadPatCommand(loritta: LorittaDiscord): ActionCommand(loritta, listOf("he
         color = Color(156, 39, 176)
 
         response { locale, sender, target ->
-            locale["commands.actions.headpat.response", sender.asMention, target.asMention]
+            locale["commands.command.headpat.response", sender.asMention, target.asMention]
         }
     }
 

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/HighFiveCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/HighFiveCommand.kt
@@ -13,7 +13,7 @@ class HighFiveCommand(loritta: LorittaDiscord): ActionCommand(loritta, listOf("h
         color = Color(27, 224, 96)
 
         response { locale, sender, target ->
-            locale["commands.actions.highfive.response", sender.asMention, target.asMention]
+            locale["commands.command.highfive.response", sender.asMention, target.asMention]
         }
     }
 

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/HugCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/HugCommand.kt
@@ -13,7 +13,7 @@ class HugCommand(loritta: LorittaDiscord): ActionCommand(loritta, listOf("hug", 
         color = Color(255, 235, 59)
 
         response { locale, sender, target ->
-            locale["commands.actions.hug.response", sender.asMention, target.asMention]
+            locale["commands.command.hug.response", sender.asMention, target.asMention]
         }
     }
 

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/KissCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/KissCommand.kt
@@ -13,7 +13,7 @@ class KissCommand(loritta: LorittaDiscord): ActionCommand(loritta, listOf("kiss"
         color = Color(233, 30, 99)
 
         response { locale, sender, target ->
-            locale["commands.actions.kiss.response", sender.asMention, target.asMention]
+            locale["commands.command.kiss.response", sender.asMention, target.asMention]
         }
     }
 

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/SlapCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/actions/modern/impl/SlapCommand.kt
@@ -15,9 +15,9 @@ class SlapCommand(loritta: LorittaDiscord): ActionCommand(loritta, listOf("slap"
 
         response { locale, sender, target ->
             if (target.id != LorittaLauncher.loritta.discordConfig.discord.clientId) {
-                locale["commands.actions.slap.response", sender.asMention, target.asMention]
+                locale["commands.command.slap.response", sender.asMention, target.asMention]
             } else {
-                locale["commands.actions.slap.responseAntiIdiot", sender.asMention, target.asMention]
+                locale["commands.command.slap.responseAntiIdiot", sender.asMention, target.asMention]
             }
         }
     }

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/administration/DashboardCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/administration/DashboardCommand.kt
@@ -9,7 +9,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 
-class DashboardCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("dashboard", "painel", "configurar", "config"), CommandCategory.ADMIN) {
+class DashboardCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("dashboard", "painel", "configurar", "config"), CommandCategory.MODERATION) {
     override fun command() = create {
         localizedDescription("commands.command.dashboard.description")
         localizedExamples("commands.command.dashboard.examples")

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/administration/DashboardCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/administration/DashboardCommand.kt
@@ -11,8 +11,8 @@ import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractComman
 
 class DashboardCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("dashboard", "painel", "configurar", "config"), CommandCategory.ADMIN) {
     override fun command() = create {
-        localizedDescription("commands.moderation.dashboard.description")
-        localizedExamples("commands.moderation.dashboard.examples")
+        localizedDescription("commands.command.dashboard.description")
+        localizedExamples("commands.command.dashboard.examples")
 
         arguments {
             argument(ArgumentType.TEXT) {

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/administration/RenameChannelCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/administration/RenameChannelCommand.kt
@@ -9,7 +9,7 @@ import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractComman
 
 class RenameChannelCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("renamechannel", "renomearcanal"), CommandCategory.ADMIN) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.moderation"
+        private const val LOCALE_PREFIX = "commands.command"
     }
     override fun command() = create {
         localizedDescription("$LOCALE_PREFIX.renamechannel.description")
@@ -84,7 +84,7 @@ class RenameChannelCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase
         } catch (e: Exception) {
                 context.reply(
                         LorittaReply(
-                                locale["commands.moderation.renamechannel.cantRename"],
+                                locale["commands.command.renamechannel.cantRename"],
                                 Constants.ERROR
                         )
                 )

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/administration/RenameChannelCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/administration/RenameChannelCommand.kt
@@ -7,7 +7,7 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 
-class RenameChannelCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("renamechannel", "renomearcanal"), CommandCategory.ADMIN) {
+class RenameChannelCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("renamechannel", "renomearcanal"), CommandCategory.MODERATION) {
     companion object {
         private const val LOCALE_PREFIX = "commands.command"
     }

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/discord/GuildBannerCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/discord/GuildBannerCommand.kt
@@ -8,7 +8,7 @@ import net.perfectdreams.loritta.api.commands.arguments
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 
-class GuildBannerCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("guildbanner", "serverbanner"), CommandCategory.ADMIN) {
+class GuildBannerCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("guildbanner", "serverbanner"), CommandCategory.MODERATION) {
     override fun command() = create {
         localizedDescription("commands.command.guildbanner.description")
 

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/discord/GuildBannerCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/discord/GuildBannerCommand.kt
@@ -10,7 +10,7 @@ import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractComman
 
 class GuildBannerCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("guildbanner", "serverbanner"), CommandCategory.ADMIN) {
     override fun command() = create {
-        localizedDescription("commands.discord.guildbanner.description")
+        localizedDescription("commands.command.guildbanner.description")
 
         arguments {
             argument(ArgumentType.TEXT) {
@@ -24,7 +24,7 @@ class GuildBannerCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(l
             val discordGuild = guild
 
             // Verificar se a guild tem banner
-            val guildBanner = discordGuild.bannerUrl ?: fail(locale["commands.discord.guildbanner.noBanner"])
+            val guildBanner = discordGuild.bannerUrl ?: fail(locale["commands.command.guildbanner.noBanner"])
 
             val embed = EmbedBuilder()
 

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/discord/RenameEmojiCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/discord/RenameEmojiCommand.kt
@@ -10,7 +10,7 @@ import java.util.regex.Pattern
 
 class RenameEmojiCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("renameemoji", "renomearemoji"), CommandCategory.DISCORD) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.discord"
+        private const val LOCALE_PREFIX = "commands.command"
     }
 
     override fun command() = create {

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/discord/RoleInfoCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/discord/RoleInfoCommand.kt
@@ -14,7 +14,7 @@ import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractComman
 
 class RoleInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("roleinfo", "taginfo"), CommandCategory.DISCORD) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.discord"
+        private const val LOCALE_PREFIX = "commands.command"
     }
 
     override fun command() = create {
@@ -71,7 +71,7 @@ class RoleInfoCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(lori
             } else {
                 context.reply(
                         LorittaReply(
-                                locale["commands.discord.roleinfo.roleNotFound"],
+                                locale["commands.command.roleinfo.roleNotFound"],
                                 Constants.ERROR
                         )
                 )

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/economy/ScratchCardCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/economy/ScratchCardCommand.kt
@@ -39,7 +39,7 @@ class ScratchCardCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(l
 		private const val GESSY_COMBO = 250
 		private const val TOBIAS_COMBO = 130
 		private val logger = KotlinLogging.logger {}
-		private const val LOCALE_PREFIX = "commands.economy"
+		private const val LOCALE_PREFIX = "commands.command"
 	}
 
 	override fun command() = create {

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/economy/ScratchCardTopCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/economy/ScratchCardTopCommand.kt
@@ -17,7 +17,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 
 class ScratchCardTopCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("scratchcard top", "raspadinha top"), CommandCategory.ECONOMY) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.economy"
+		private const val LOCALE_PREFIX = "commands.command"
 	}
 
 	override fun command() = create {

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/AsciiCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/AsciiCommand.kt
@@ -11,7 +11,7 @@ import net.perfectdreams.loritta.utils.ImageToAsciiConverter
 
 class AsciiCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("ascii", "asciiart", "img2ascii", "img2asciiart", "image2ascii"), CommandCategory.IMAGES) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.images"
+        private const val LOCALE_PREFIX = "commands.command"
     }
 
     override fun command() = create {

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/AtendenteCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/AtendenteCommand.kt
@@ -18,7 +18,7 @@ import java.io.File
 
 class AtendenteCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("atendente"), CommandCategory.IMAGES) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.images.atendente"
+        private const val LOCALE_PREFIX = "commands.command.atendente"
     }
 
     override fun command() = create {

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/DrawnWordCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/DrawnWordCommand.kt
@@ -19,7 +19,7 @@ import java.io.File
 
 class DrawnWordCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("drawnword"), CommandCategory.IMAGES) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.images"
+        private const val LOCALE_PREFIX = "commands.command"
     }
 
     override fun command() = create {

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/EmojiMashupCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/EmojiMashupCommand.kt
@@ -15,7 +15,7 @@ import java.io.File
 
 open class EmojiMashupCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("emojimashup", "emojismashup", "mashupemoji", "mashupemojis", "mituraremojis", "misturaremoji"), CommandCategory.IMAGES) {
 	companion object {
-		private const val LOCALE_PREFIX = "commands.images"
+		private const val LOCALE_PREFIX = "commands.command"
 	}
 
 	override fun command() = create {

--- a/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/TristeRealidadeCommand.kt
+++ b/loritta-plugins/artsy-joy-lori/src/main/kotlin/net/perfectdreams/loritta/commands/images/TristeRealidadeCommand.kt
@@ -24,7 +24,7 @@ import java.awt.image.BufferedImage
 
 class TristeRealidadeCommand(loritta: LorittaDiscord) : DiscordAbstractCommandBase(loritta, listOf("sadreality", "tristerealidade"), CommandCategory.IMAGES) {
     companion object {
-        private const val LOCALE_PREFIX = "commands.images"
+        private const val LOCALE_PREFIX = "commands.command"
     }
 
     override fun command() = create {

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/FortniteShopGenerator.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/FortniteShopGenerator.kt
@@ -106,11 +106,11 @@ class FortniteShopGenerator(val parse: JsonObject, val creatorCode: String) {
         graphics.color = Color(203, 210, 220)
         graphics.font = Constants.BURBANK_BIG_CONDENSED_BLACK.deriveFont(27f)
 
-        val subHeaderApplyPath = makeFortniteHeader(graphics.fontMetrics, locale["commands.fortnite.shop.featuredItems"])
+        val subHeaderApplyPath = makeFortniteHeader(graphics.fontMetrics, locale["commands.command.shop.featuredItems"])
 
         graphics.drawImage(subHeaderApplyPath, PADDING, 0 + PADDING, null)
 
-        val subHeaderApplyPathItems = makeFortniteHeader(graphics.fontMetrics, locale["commands.fortnite.shop.dailyItems"])
+        val subHeaderApplyPathItems = makeFortniteHeader(graphics.fontMetrics, locale["commands.command.shop.dailyItems"])
         graphics.drawImage(subHeaderApplyPathItems, 512 + PADDING + PADDING_BETWEEN_SECTIONS + PADDING, 0 + PADDING, null)
 
         run {
@@ -170,7 +170,7 @@ class FortniteShopGenerator(val parse: JsonObject, val creatorCode: String) {
         graphics.font = Constants.BURBANK_BIG_CONDENSED_BOLD.deriveFont(27f)
         graphics.color = Color(255, 255, 255, 120)
 
-        val creatorCodeText = locale["commands.fortnite.shop.creatorCode", creatorCode]
+        val creatorCodeText = locale["commands.command.shop.creatorCode", creatorCode]
         graphics.drawString(
                 creatorCodeText,
                 bufImage.width - graphics.fontMetrics.stringWidth(creatorCodeText) - 15,

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/FortniteStuff.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/FortniteStuff.kt
@@ -69,7 +69,7 @@ class FortniteStuff(name: String, loritta: LorittaDiscord) : LorittaDiscordPlugi
                 }
             }.distinctBy { it["id"].string }
 
-            val fortniteItemsInCurrentLocale = m.itemsInfo[locale["commands.fortnite.shop.localeId"]]!!
+            val fortniteItemsInCurrentLocale = m.itemsInfo[locale["commands.command.shop.localeId"]]!!
 
             val embed = EmbedBuilder()
 
@@ -86,7 +86,7 @@ class FortniteStuff(name: String, loritta: LorittaDiscord) : LorittaDiscordPlugi
                         val item = items[i].obj
                         val fortniteItemInCurrentLocale = fortniteItemsInCurrentLocale.first { item["id"].string == it["id"].string }.obj
 
-                        embed.setTitle("${Emotes.LORI_HM} ${locale["commands.fortnite.item.multipleItems"]}")
+                        embed.setTitle("${Emotes.LORI_HM} ${locale["commands.command.item.multipleItems"]}")
                         embed.setColor(Color(0, 125, 187))
                         embed.appendDescription("${Constants.INDEXES[i]} ${fortniteItemInCurrentLocale["name"].nullString} (${fortniteItemInCurrentLocale["type"]["value"].nullString})\n")
                     }

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/UpdateStoreItemsTask.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/UpdateStoreItemsTask.kt
@@ -61,7 +61,7 @@ class UpdateStoreItemsTask(val m: FortniteStuff) {
 							lastItemListPostUpdate = System.currentTimeMillis()
 							logger.info { "Updating Fortnite Items..." }
 							val distinctApiIds = loritta.locales.values.map {
-								it["commands.fortnite.shop.localeId"]
+								it["commands.command.shop.localeId"]
 							}.distinct()
 
 							for (apiId in distinctApiIds) {
@@ -105,7 +105,7 @@ class UpdateStoreItemsTask(val m: FortniteStuff) {
 		logger.info { "Updating Fortnite Shop..." }
 
 		val distinctApiIds = loritta.locales.values.map {
-			it["commands.fortnite.shop.localeId"]
+			it["commands.command.shop.localeId"]
 		}.distinct()
 
 		logger.info { "There are ${distinctApiIds.size} distinct API IDs: $distinctApiIds" }
@@ -121,7 +121,7 @@ class UpdateStoreItemsTask(val m: FortniteStuff) {
 		var alreadyNotifiedUsers = false
 
 		for (locale in loritta.locales.values) {
-			val apiLocaleId = locale["commands.fortnite.shop.localeId"]
+			val apiLocaleId = locale["commands.command.shop.localeId"]
 			logger.info { "Updating shop for ${locale.id}... API Locale ID is $apiLocaleId, Shop Data is ${shopsData[apiLocaleId]}" }
 
 			val shopData = try { shopsData[apiLocaleId]?.await() } catch (e: Exception) { continue } ?: continue
@@ -229,8 +229,8 @@ class UpdateStoreItemsTask(val m: FortniteStuff) {
 										.setTitle("${Emotes.DEFAULT_DANCE} ${storeItem["name"].string} voltou para a loja!")
 										.setThumbnail(storeItem["images"]["smallIcon"].string)
 										.setDescription("O item que você pediu para ser notificado voltou para a loja! Espero que você tenha economizado os V-Bucks para comprar. ${Emotes.LORI_HAPPY}\n\nPor favor use o código de criador `MrPowerGamerBR` na loja de itens antes de comprar! Assim você me ajuda a ficar online, para que eu possa continuar a te notificar novos itens! ${Emotes.LORI_OWO}")
-										.addField("\uD83D\uDD16 ${locale["commands.fortnite.item.type"]}", storeItem["type"]["displayValue"].nullString, true)
-										.addField("⭐ ${locale["commands.fortnite.item.rarity"]}", storeItem["rarity"]["displayValue"].nullString, true)
+										.addField("\uD83D\uDD16 ${locale["commands.command.item.type"]}", storeItem["type"]["displayValue"].nullString, true)
+										.addField("⭐ ${locale["commands.command.item.rarity"]}", storeItem["rarity"]["displayValue"].nullString, true)
 										.setColor(FortniteStuff.convertRarityToColor(storeItem["rarity"]["value"].nullString
 												?: "???"))
 										.build()

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteItemCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteItemCommand.kt
@@ -15,11 +15,11 @@ import net.perfectdreams.loritta.plugin.fortnite.FortniteStuff
 import net.perfectdreams.loritta.utils.Emotes
 
 class FortniteItemCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.loritta, listOf("fortniteitem", "fnitem"), CommandCategory.FORTNITE) {
-	private val LOCALE_PREFIX = "commands.fortnite.item"
+	private val LOCALE_PREFIX = "commands.command.item"
 
 	override fun command() = create {
 		localizedDescription("${LOCALE_PREFIX}.description")
-		localizedExamples("commands.fortnite.itemsExamples")
+		localizedExamples("commands.category.fortnite.itemsExamples")
 
 		needsToUploadFiles = true
 

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteNewsCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteNewsCommand.kt
@@ -16,14 +16,14 @@ import java.io.File
 import javax.imageio.stream.FileImageOutputStream
 
 class FortniteNewsCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.loritta, listOf("fortnitenews", "fortnitenoticias", "fortnitenotícias", "fnnews", "fnnoticias", "fnnotícias"), CommandCategory.FORTNITE) {
-	private val LOCALE_PREFIX = "commands.fortnite.news"
+	private val LOCALE_PREFIX = "commands.command.news"
 
 	override fun command() = create {
 		localizedDescription("${LOCALE_PREFIX}.description")
 		needsToUploadFiles = true
 
 		executesDiscord {
-			val newsPayload = m.updateStoreItems!!.getNewsData("br", locale["commands.fortnite.shop.localeId"])
+			val newsPayload = m.updateStoreItems!!.getNewsData("br", locale["commands.command.shop.localeId"])
 
 			val data = newsPayload.obj["data"]["motds"].array
 

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteNotifyCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteNotifyCommand.kt
@@ -22,11 +22,11 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import java.awt.Color
 
 class FortniteNotifyCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.loritta, listOf("fnnotify", "fortnitenotify", "fnnotificar", "fortnitenotificar"), CommandCategory.FORTNITE) {
-	private val LOCALE_PREFIX = "commands.fortnite.notify"
+	private val LOCALE_PREFIX = "commands.command.notify"
 
 	override fun command() = create {
 		localizedDescription("${LOCALE_PREFIX}.description")
-		localizedExamples("commands.fortnite.itemsExamples")
+		localizedExamples("commands.category.fortnite.itemsExamples")
 
 		needsToUploadFiles = true
 
@@ -35,7 +35,7 @@ class FortniteNotifyCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m
 		}
 
 		executesDiscord {
-			val fortniteItemsInCurrentLocale = m.itemsInfo[locale["commands.fortnite.shop.localeId"]]!!
+			val fortniteItemsInCurrentLocale = m.itemsInfo[locale["commands.command.shop.localeId"]]!!
 
 			if (args.isEmpty()) {
 				val alreadyTracking = transaction(Databases.loritta) {

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteShopCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteShopCommand.kt
@@ -8,7 +8,7 @@ import net.perfectdreams.loritta.plugin.fortnite.FortniteStuff
 import net.perfectdreams.loritta.utils.Emotes
 
 class FortniteShopCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.loritta, listOf("fortniteshop", "fortniteloja", "fnshop", "fnloja"), CommandCategory.FORTNITE) {
-	private val LOCALE_PREFIX = "commands.fortnite.shop"
+	private val LOCALE_PREFIX = "commands.command.shop"
 
 	override fun command() = create {
 		localizedDescription("${LOCALE_PREFIX}.description")
@@ -24,7 +24,7 @@ class FortniteShopCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.l
 			if (storeFileName == null) {
 				reply(
 						LorittaReply(
-								locale["commands.fortnite.shop.notLoadedYet"],
+								locale["commands.command.shop.notLoadedYet"],
 								Constants.ERROR
 						)
 				)

--- a/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteStatsCommand.kt
+++ b/loritta-plugins/fortnite-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/fortnite/commands/fortnite/FortniteStatsCommand.kt
@@ -20,7 +20,7 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 
 class FortniteStatsCommand(val m: FortniteStuff) : DiscordAbstractCommandBase(m.loritta, listOf("fortnitestats", "fnstats", "fortniteprofile", "fnprofile"), CommandCategory.FORTNITE) {
-	private val LOCALE_PREFIX = "commands.fortnite.stats"
+	private val LOCALE_PREFIX = "commands.command.stats"
 
 	override fun command() = create {
 		localizedDescription("${LOCALE_PREFIX}.description")

--- a/loritta-plugins/funfunfun/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/funfunfun/commands/CancelledCommand.kt
+++ b/loritta-plugins/funfunfun/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/funfunfun/commands/CancelledCommand.kt
@@ -9,8 +9,8 @@ import net.perfectdreams.loritta.utils.Emotes
 
 class CancelledCommand(val m: FunFunFunPlugin) : LorittaAbstractCommandBase(m.loritta, listOf("cancelled", "cancelado", "cancel", "cancelar"), CommandCategory.FUN) {
 	override fun command() = create {
-		localizedDescription("commands.fun.cancelled.description")
-		localizedExamples("commands.fun.cancelled.examples")
+		localizedDescription("commands.command.cancelled.description")
+		localizedExamples("commands.command.cancelled.examples")
 
 		usage {
 			argument(ArgumentType.USER) {}
@@ -21,7 +21,7 @@ class CancelledCommand(val m: FunFunFunPlugin) : LorittaAbstractCommandBase(m.lo
 
 			reply(
 					LorittaReply(
-							locale["commands.fun.cancelled.wasCancelled", user.asMention, locale.getList("commands.fun.cancelled.reasons").random()],
+							locale["commands.command.cancelled.wasCancelled", user.asMention, locale.getList("commands.command.cancelled.reasons").random()],
 							Emotes.LORI_HMPF
 					)
 			)

--- a/loritta-plugins/funfunfun/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/funfunfun/commands/HungerGamesCommand.kt
+++ b/loritta-plugins/funfunfun/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/funfunfun/commands/HungerGamesCommand.kt
@@ -17,7 +17,7 @@ import net.perfectdreams.loritta.utils.extensions.toJDA
 import org.jsoup.Jsoup
 
 class HungerGamesCommand(m: FunFunFunPlugin) : DiscordAbstractCommandBase(m.loritta as LorittaDiscord, listOf("hungergames", "jogosvorazes", "hg"), CommandCategory.FUN) {
-    private val LOCALE_PREFIX = "commands.fun.hungergames"
+    private val LOCALE_PREFIX = "commands.command.hungergames"
     private val WEBSITE_URL = "https://brantsteele.net"
 
     override fun command() = create {

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/CoinFlipBetCommand.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/CoinFlipBetCommand.kt
@@ -34,8 +34,8 @@ class CoinFlipBetCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractComman
 	}
 
 	override fun command() = create {
-		localizedDescription("commands.economy.flipcoinbet.description")
-		localizedExamples("commands.economy.flipcoinbet.examples")
+		localizedDescription("commands.command.flipcoinbet.description")
+		localizedExamples("commands.command.flipcoinbet.examples")
 
 		usage {
 			arguments {
@@ -54,7 +54,7 @@ class CoinFlipBetCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractComman
 			val invitedUser = _user.toJDA()
 
 			if (invitedUser == user)
-				fail(locale["commands.economy.flipcoinbet.cantBetSelf"], Constants.ERROR)
+				fail(locale["commands.command.flipcoinbet.cantBetSelf"], Constants.ERROR)
 
 			val selfActiveDonations = loritta.getActiveMoneyFromDonationsAsync(discordMessage.author.idLong)
 			val otherActiveDonations = loritta.getActiveMoneyFromDonationsAsync(invitedUser.idLong)
@@ -87,21 +87,21 @@ class CoinFlipBetCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractComman
 			val money = number - tax
 
 			if (!hasNoTax && tax == 0L)
-				fail(locale["commands.economy.flipcoinbet.youNeedToBetMore"], Constants.ERROR)
+				fail(locale["commands.command.flipcoinbet.youNeedToBetMore"], Constants.ERROR)
 
 			if (0 >= number)
-				fail(locale["commands.economy.flipcoinbet.zeroMoney"], Constants.ERROR)
+				fail(locale["commands.command.flipcoinbet.zeroMoney"], Constants.ERROR)
 
 			val selfUserProfile = lorittaUser.profile
 
 			if (number > selfUserProfile.money)
-				fail(locale["commands.economy.flipcoinbet.notEnoughMoneySelf"], Constants.ERROR)
+				fail(locale["commands.command.flipcoinbet.notEnoughMoneySelf"], Constants.ERROR)
 
 			val invitedUserProfile = loritta.getOrCreateLorittaProfile(invitedUser.id)
 			val bannedState = invitedUserProfile.getBannedState()
 
 			if (number > invitedUserProfile.money || bannedState != null)
-				fail(locale["commands.economy.flipcoinbet.notEnoughMoneyInvited", invitedUser.asMention], Constants.ERROR)
+				fail(locale["commands.command.flipcoinbet.notEnoughMoneyInvited", invitedUser.asMention], Constants.ERROR)
 
 			// Only allow users to participate in a coin flip bet if the user got their daily reward today
 			AccountUtils.getUserTodayDailyReward(lorittaUser.profile)
@@ -111,22 +111,22 @@ class CoinFlipBetCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractComman
 					LorittaReply(
 						if (hasNoTax)
 							locale[
-									"commands.economy.flipcoinbet.startBetNoTax",
+									"commands.command.flipcoinbet.startBetNoTax",
 									invitedUser.asMention,
 									user.asMention,
-									locale["commands.fun.flipcoin.heads"],
+									locale["commands.command.flipcoin.heads"],
 									money,
-									locale["commands.fun.flipcoin.tails"],
+									locale["commands.command.flipcoin.tails"],
 									whoHasTheNoTaxReward?.asMention ?: "???"
 							]
 						else
 							locale[
-									"commands.economy.flipcoinbet.startBet",
+									"commands.command.flipcoinbet.startBet",
 									invitedUser.asMention,
 									user.asMention,
-									locale["commands.fun.flipcoin.heads"],
+									locale["commands.command.flipcoin.heads"],
 									money,
-									locale["commands.fun.flipcoin.tails"],
+									locale["commands.command.flipcoin.tails"],
 									number,
 									tax
 							],
@@ -135,7 +135,7 @@ class CoinFlipBetCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractComman
 					),
 					LorittaReply(
 							locale[
-									"commands.economy.flipcoinbet.clickToAcceptTheBet",
+									"commands.command.flipcoinbet.clickToAcceptTheBet",
 									invitedUser.asMention,
 									"✅"
 							],
@@ -217,7 +217,7 @@ class CoinFlipBetCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractComman
 														mentionUser = false
 												),
 												LorittaReply(
-														locale["commands.economy.flipcoinbet.congratulations", winner.asMention, money, loser.asMention],
+														locale["commands.command.flipcoinbet.congratulations", winner.asMention, money, loser.asMention],
 														Emotes.LORI_RICH,
 														mentionUser = false
 												)

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/CoinFlipBetStatsCommand.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/CoinFlipBetStatsCommand.kt
@@ -22,8 +22,8 @@ class CoinFlipBetStatsCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractC
 		CommandCategory.ECONOMY
 ) {
 	override fun command() = create {
-		localizedDescription("commands.economy.flipcoinbetstats.description")
-		localizedExamples("commands.economy.flipcoinbetstats.examples")
+		localizedDescription("commands.command.flipcoinbetstats.description")
+		localizedExamples("commands.command.flipcoinbetstats.examples")
 
 		usage {
 			arguments {
@@ -62,7 +62,7 @@ class CoinFlipBetStatsCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractC
 
 			if (playedCount == 0L)
 			// Never played!
-				fail(locale["commands.economy.flipcoinbetstats.playerHasNeverPlayed"])
+				fail(locale["commands.command.flipcoinbetstats.playerHasNeverPlayed"])
 
 			val sumField = SonhosTransaction.quantity.sum()
 			val winSum = loritta.newSuspendedTransaction {
@@ -85,43 +85,43 @@ class CoinFlipBetStatsCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractC
 			reply(
 					LorittaReply(
 							if (checkingYourself)
-								locale["commands.economy.flipcoinbetstats.yourStats"]
+								locale["commands.command.flipcoinbetstats.yourStats"]
 							else
-								locale["commands.economy.flipcoinbetstats.statsOfUser", checkStatsOfUser.asMention]
+								locale["commands.command.flipcoinbetstats.statsOfUser", checkStatsOfUser.asMention]
 							,
 							Emotes.LORI_RICH
 					),
 					LorittaReply(
-							locale["commands.economy.flipcoinbetstats.playedMatches", playedCount],
+							locale["commands.command.flipcoinbetstats.playedMatches", playedCount],
 							mentionUser = false
 					),
 					LorittaReply(
-							locale["commands.economy.flipcoinbetstats.wonMatches", winPercentage, winCount],
+							locale["commands.command.flipcoinbetstats.wonMatches", winPercentage, winCount],
 							mentionUser = false
 					),
 					LorittaReply(
-							locale["commands.economy.flipcoinbetstats.lostMatches", losePercentage, loseCount],
+							locale["commands.command.flipcoinbetstats.lostMatches", losePercentage, loseCount],
 							mentionUser = false
 					),
 					LorittaReply(
-							locale["commands.economy.flipcoinbetstats.wonSonhos", winSum],
+							locale["commands.command.flipcoinbetstats.wonSonhos", winSum],
 							mentionUser = false
 					),
 					LorittaReply(
-							locale["commands.economy.flipcoinbetstats.lostSonhos", loseSum],
+							locale["commands.command.flipcoinbetstats.lostSonhos", loseSum],
 							mentionUser = false
 					),
 					LorittaReply(
-							locale["commands.economy.flipcoinbetstats.totalSonhos", winSum - loseSum],
+							locale["commands.command.flipcoinbetstats.totalSonhos", winSum - loseSum],
 							mentionUser = false
 					),
 					LorittaReply(
-							locale["commands.economy.flipcoinbetstats.probabilityExplanation"],
+							locale["commands.command.flipcoinbetstats.probabilityExplanation"],
 							Emotes.LORI_COFFEE,
 							mentionUser = false
 					),
 					LorittaReply(
-							locale["commands.economy.flipcoinbetstats.bugsDoesntExist"],
+							locale["commands.command.flipcoinbetstats.bugsDoesntExist"],
 							Emotes.LORI_BAN_HAMMER,
 							mentionUser = false
 					)

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/EmojiFightBetCommand.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/EmojiFightBetCommand.kt
@@ -17,8 +17,8 @@ class EmojiFightBetCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractComm
 		CommandCategory.ECONOMY
 ) {
 	override fun command() = create {
-		localizedDescription("commands.economy.emojifightbet.description")
-		localizedExamples("commands.economy.emojifightbet.examples")
+		localizedDescription("commands.command.emojifightbet.description")
+		localizedExamples("commands.command.emojifightbet.examples")
 
 		usage {
 			arguments {
@@ -43,12 +43,12 @@ class EmojiFightBetCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractComm
 					}
 
 			if (0 >= totalEarnings)
-				fail(locale["commands.economy.flipcoinbet.zeroMoney"], Constants.ERROR)
+				fail(locale["commands.command.flipcoinbet.zeroMoney"], Constants.ERROR)
 
 			val selfUserProfile = lorittaUser.profile
 
 			if (totalEarnings > selfUserProfile.money)
-				fail(locale["commands.economy.flipcoinbet.notEnoughMoneySelf"], Constants.ERROR)
+				fail(locale["commands.command.flipcoinbet.notEnoughMoneySelf"], Constants.ERROR)
 
 			// Only allow users to participate in a emoji fight bet if the user got their daily reward today
 			AccountUtils.getUserTodayDailyReward(lorittaUser.profile)

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/EmojiFightCommand.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/EmojiFightCommand.kt
@@ -13,7 +13,7 @@ class EmojiFightCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractCommand
 		CommandCategory.ECONOMY
 ) {
 	override fun command() = create {
-		localizedDescription("commands.economy.emojifight.description")
+		localizedDescription("commands.command.emojifight.description")
 
 		usage {
 			arguments {

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/GuessNumberCommand.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/GuessNumberCommand.kt
@@ -22,8 +22,8 @@ class GuessNumberCommand(plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
     }
 
     override fun command() = create {
-        localizedDescription("commands.economy.guessnumber.description")
-        localizedExamples("commands.economy.guessnumber.examples")
+        localizedDescription("commands.command.guessnumber.description")
+        localizedExamples("commands.command.guessnumber.examples")
 
         usage {
             arguments {
@@ -44,12 +44,12 @@ class GuessNumberCommand(plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
                     }
 
             if (number !in 1..10)
-                fail(locale["commands.economy.guessnumber.numberNotInRange", VICTORY_PRIZE])
+                fail(locale["commands.command.guessnumber.numberNotInRange", VICTORY_PRIZE])
 
             val profile = lorittaUser.profile
 
             if (LOSE_PRIZE > profile.money)
-                fail(locale["commands.economy.guessnumber.notEnoughSonhos"])
+                fail(locale["commands.command.guessnumber.notEnoughSonhos"])
 
             val randomNumber = Loritta.RANDOM.nextInt(1, 11)
             val won = number == randomNumber
@@ -65,7 +65,7 @@ class GuessNumberCommand(plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
                     )
                 }
 
-                reply(locale["commands.economy.guessnumber.youWin", VICTORY_PRIZE], Emotes.LORI_RICH)
+                reply(locale["commands.command.guessnumber.youWin", VICTORY_PRIZE], Emotes.LORI_RICH)
             } else {
                 loritta.newSuspendedTransaction {
                     profile.takeSonhosNested(LOSE_PRIZE)
@@ -77,7 +77,7 @@ class GuessNumberCommand(plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
                     )
                 }
 
-                reply(locale.getList("commands.economy.guessnumber.youLose", randomNumber, LOSE_PRIZE).random(), Emotes.LORI_CRYING)
+                reply(locale.getList("commands.command.guessnumber.youLose", randomNumber, LOSE_PRIZE).random(), Emotes.LORI_CRYING)
             }
         }
     }

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/RepListCommand.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/RepListCommand.kt
@@ -22,8 +22,8 @@ class RepListCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
         CommandCategory.SOCIAL
 ) {
     override fun command() = create {
-        localizedDescription("commands.social.repList.description")
-        localizedExamples("commands.social.repList.examples")
+        localizedDescription("commands.command.replist.description")
+        localizedExamples("commands.command.replist.examples")
 
         usage {
             arguments {
@@ -58,9 +58,9 @@ class RepListCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
 
             val description = buildString {
                 if (reputations.size == 0) {
-                    this.append(locale["commands.social.repList.noReps"])
+                    this.append(locale["commands.command.replist.noReps"])
                 } else {
-                    this.append(locale["commands.social.repList.reputationsTotalDescription", totalReputationReceived, totalReputationGiven])
+                    this.append(locale["commands.command.replist.reputationsTotalDescription", totalReputationReceived, totalReputationGiven])
                     this.append("\n")
                     this.append("\n")
 
@@ -101,19 +101,19 @@ class RepListCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
 
                         val receivedByLoritta = reputation[Reputations.givenById] == com.mrpowergamerbr.loritta.utils.loritta.discordConfig.discord.clientId.toLong()
                         if (receivedByLoritta) {
-                            str.append(locale["commands.social.repList.receivedReputationByLoritta", "`${user.name + "#" + user.discriminator}`"])
+                            str.append(locale["commands.command.replist.receivedReputationByLoritta", "`${user.name + "#" + user.discriminator}`"])
                         } else {
                             if (receivedReputation) {
                                 if (content.isNullOrBlank()) {
-                                    str.append(locale["commands.social.repList.receivedReputation", "`${name}`"])
+                                    str.append(locale["commands.command.replist.receivedReputation", "`${name}`"])
                                 } else {
-                                    str.append(locale["commands.social.repList.receivedReputationWithContent", "`${name}`", "`$content`"])
+                                    str.append(locale["commands.command.replist.receivedReputationWithContent", "`${name}`", "`$content`"])
                                 }
                             } else {
                                 if (content.isNullOrBlank()) {
-                                    str.append(locale["commands.social.repList.sentReputation", "`${name}`"])
+                                    str.append(locale["commands.command.replist.sentReputation", "`${name}`"])
                                 } else {
-                                    str.append(locale["commands.social.repList.sentReputationWithContent", "`${name}`", "`$content`"])
+                                    str.append(locale["commands.command.replist.sentReputationWithContent", "`${name}`", "`$content`"])
                                 }
                             }
                         }
@@ -134,9 +134,9 @@ class RepListCommand(val plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
                     .setTitle(
                             "${Emotes.LORI_RICH} " +
                                     if (user != user)
-                                        locale["commands.social.repList.otherUserRepList", user.asTag]
+                                        locale["commands.command.replist.otherUserRepList", user.asTag]
                                     else
-                                        locale["commands.social.repList.title"]
+                                        locale["commands.command.replist.title"]
                     )
                     .setColor(Constants.LORITTA_AQUA)
                     .setDescription(description)

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/utils/EmojiFight.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/utils/EmojiFight.kt
@@ -45,7 +45,7 @@ class EmojiFight(
             val tax = (entryPrice * (1.0 * UserPremiumPlans.Free.totalCoinFlipReward)).toLong()
 
             if (tax == 0L)
-                context.fail(context.locale["commands.economy.flipcoinbet.youNeedToBetMore"], Constants.ERROR)
+                context.fail(context.locale["commands.command.flipcoinbet.youNeedToBetMore"], Constants.ERROR)
         }
 
         addToFightEvent(context.user)
@@ -112,28 +112,28 @@ class EmojiFight(
 
     private fun getEventEmbed(): MessageEmbed {
         val baseEmbed = EmbedBuilder()
-                .setTitle("${Emotes.LORI_BAN_HAMMER} ${context.locale["commands.economy.emojifight.fightTitle"]}")
+                .setTitle("${Emotes.LORI_BAN_HAMMER} ${context.locale["commands.command.emojifight.fightTitle"]}")
                 .setDescription(
                         if (entryPrice != null) {
                             context.locale
                                     .getList(
-                                            "commands.economy.emojifightbet.fightDescription",
+                                            "commands.command.emojifightbet.fightDescription",
                                             entryPrice,
                                             entryPrice * (participatingUsers.size - 1), // Needs to subtract -1 because the winner *won't* pay for his win
                                             "\uD83D\uDC14",
                                             context.user.asMention,
                                             "✅"
-                                    ).joinToString("\n") + "\n\n**" + context.locale["commands.economy.emojifight.participants", participatingUsers.size] + "**\n"
+                                    ).joinToString("\n") + "\n\n**" + context.locale["commands.command.emojifight.participants", participatingUsers.size] + "**\n"
                         } else {
                             context.locale
                                     .getList(
-                                            "commands.economy.emojifight.fightDescription",
+                                            "commands.command.emojifight.fightDescription",
                                             Emotes.LORI_PAT,
                                             context.serverConfig.commandPrefix,
                                             "\uD83D\uDC14",
                                             context.user.asMention,
                                             "✅"
-                                    ).joinToString("\n") + "\n\n**" + context.locale["commands.economy.emojifight.participants", participatingUsers.size] + "**\n"
+                                    ).joinToString("\n") + "\n\n**" + context.locale["commands.command.emojifight.participants", participatingUsers.size] + "**\n"
                         }
                 )
                 .setColor(Constants.ROBLOX_RED)
@@ -255,7 +255,7 @@ class EmojiFight(
         val (winner, losers, realPrize, taxedRealPrize) = result ?: run {
             // Needs to use "reply" because if we use "fail", the exception is triggered on the onReactionAddByAuthor
             context.reply(
-                    context.locale["commands.economy.emojifight.needsMorePlayers"],
+                    context.locale["commands.command.emojifight.needsMorePlayers"],
                     Emotes.LORI_CRYING
             )
             return
@@ -266,9 +266,9 @@ class EmojiFight(
 
             // If the tax == 0, then it means that the user is premium!
             val localeKey = if (tax == 0L)
-                "commands.economy.emojifightbet.wonBet"
+                "commands.command.emojifightbet.wonBet"
             else
-                "commands.economy.emojifightbet.wonBetTaxed"
+                "commands.command.emojifightbet.wonBetTaxed"
 
             context.reply(
                     context.locale[
@@ -286,7 +286,7 @@ class EmojiFight(
         } else {
             context.reply(
                     context.locale[
-                            "commands.economy.emojifight.wonBet",
+                            "commands.command.emojifight.wonBet",
                             winner.value,
                             winner.key.asMention
                     ],

--- a/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerBuyStockCommand.kt
+++ b/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerBuyStockCommand.kt
@@ -23,7 +23,7 @@ class BrokerBuyStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComma
 	}
 
 	override fun command() = create {
-		localizedDescription("commands.economy.brokerBuy.description")
+		localizedDescription("commands.command.brokerbuy.description")
 
 		arguments {
 			argument(ArgumentType.TEXT) {}
@@ -38,17 +38,17 @@ class BrokerBuyStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComma
 					?: explainAndExit()
 
 			if (!plugin.validStocksCodes.any { it == this.args[0] })
-				fail(locale["commands.economy.broker.invalidTickerId", locale["commands.economy.brokerBuy.baseExample", serverConfig.commandPrefix]])
+				fail(locale["commands.command.broker.invalidTickerId", locale["commands.command.brokerbuy.baseExample", serverConfig.commandPrefix]])
 
 			val ticker = plugin.tradingApi
 					.getOrRetrieveTicker(tickerId, listOf(LoriBrokerPlugin.CURRENT_PRICE_FIELD, "description"))
 
 			if (ticker["current_session"]!!.jsonPrimitive.content != LoriBrokerPlugin.MARKET)
-				fail(locale["commands.economy.broker.outOfSession"])
+				fail(locale["commands.command.broker.outOfSession"])
 
 			val mutex = plugin.mutexes.getOrPut(user.idLong, { Mutex() })
 			if (mutex.isLocked)
-				fail(locale["commands.economy.broker.alreadyExecutingAction"])
+				fail(locale["commands.command.broker.alreadyExecutingAction"])
 
 			val quantity = this.args.getOrNull(1) ?: "1"
 
@@ -56,7 +56,7 @@ class BrokerBuyStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComma
 					?: GenericReplies.invalidNumber(this, quantity)
 
 			if (0 >= number)
-				fail(locale["commands.economy.brokerBuy.zeroValue"], Constants.ERROR)
+				fail(locale["commands.command.brokerbuy.zeroValue"], Constants.ERROR)
 
 			val selfUserProfile = lorittaUser.profile
 
@@ -67,7 +67,7 @@ class BrokerBuyStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComma
 			val howMuchValue = valueOfStock * number
 
 			if (howMuchValue > selfUserProfile.money)
-				fail(locale["commands.economy.brokerBuy.notEnoughMoney"], Constants.ERROR)
+				fail(locale["commands.command.brokerbuy.notEnoughMoney"], Constants.ERROR)
 
 			val user = user
 			val now = System.currentTimeMillis()
@@ -80,7 +80,7 @@ class BrokerBuyStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComma
 					}.count()
 
 					if (number + currentStockCount > LoriBrokerPlugin.MAX_STOCKS)
-						fail(locale["commands.economy.brokerBuy.tooManyStocks", LoriBrokerPlugin.MAX_STOCKS])
+						fail(locale["commands.command.brokerbuy.tooManyStocks", LoriBrokerPlugin.MAX_STOCKS])
 
 					// By using shouldReturnGeneratedValues, the database won't need to synchronize on each insert
 					// this increases insert performance A LOT and, because we don't need the IDs, it is very useful to make
@@ -105,11 +105,11 @@ class BrokerBuyStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComma
 			reply(
 					LorittaReply(
 							locale[
-									"commands.economy.brokerBuy.successfullyBought",
+									"commands.command.brokerbuy.successfullyBought",
 									number,
-									locale["commands.economy.broker.stocks.${if (number == 1L) "one" else "multiple"}"],
+									locale["commands.command.broker.stocks.${if (number == 1L) "one" else "multiple"}"],
 									tickerId,
-									locale["commands.economy.broker.portfolioExample", serverConfig.commandPrefix]
+									locale["commands.command.broker.portfolioExample", serverConfig.commandPrefix]
 							],
 							Emotes.LORI_RICH
 					)

--- a/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerCommand.kt
+++ b/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerCommand.kt
@@ -14,7 +14,7 @@ import org.jetbrains.exposed.sql.selectAll
 
 class BrokerCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractCommandBase(plugin.loritta, plugin.aliases, CommandCategory.ECONOMY) {
 	override fun command() = create {
-		localizedDescription("commands.economy.broker.description")
+		localizedDescription("commands.command.broker.description")
 
 		executesDiscord {
 			if (this.args.getOrNull(0) == "sell_all" && this.user.idLong == 123170274651668480L) {
@@ -62,18 +62,18 @@ class BrokerCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractCommandBase(p
 			}
 
 			val embed = plugin.getBaseEmbed()
-					.setTitle("${Emotes.LORI_STONKS} ${locale["commands.economy.broker.title"]}")
+					.setTitle("${Emotes.LORI_STONKS} ${locale["commands.command.broker.title"]}")
 					.setDescription(
 							locale.getList(
-									"commands.economy.broker.explanation",
-									locale["commands.economy.broker.buyExample", serverConfig.commandPrefix],
-									locale["commands.economy.broker.sellExample", serverConfig.commandPrefix],
-									locale["commands.economy.broker.portfolioExample", serverConfig.commandPrefix],
+									"commands.command.broker.explanation",
+									locale["commands.command.broker.buyExample", serverConfig.commandPrefix],
+									locale["commands.command.broker.sellExample", serverConfig.commandPrefix],
+									locale["commands.command.broker.portfolioExample", serverConfig.commandPrefix],
 									Emotes.DO_NOT_DISTURB,
 									Emotes.LORI_CRYING
 							).joinToString("\n")
 					)
-					.setFooter(locale["commands.economy.broker.footer"])
+					.setFooter(locale["commands.command.broker.footer"])
 
 			// Sorted by the ticker name
 			for (stock in stocks.sortedBy { it["short_name"]!!.jsonPrimitive.content }) {
@@ -88,14 +88,14 @@ class BrokerCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractCommandBase(p
 				if (stock["current_session"]!!.jsonPrimitive.content != LoriBrokerPlugin.MARKET)
 					embed.addField(
 							"${Emotes.DO_NOT_DISTURB} `${stock["short_name"]?.jsonPrimitive?.content}` ($tickerName) | ${"%.2f".format(changePercentage)}%",
-							locale["commands.economy.broker.priceBeforeMarketClose", plugin.convertReaisToSonhos(stock[LoriBrokerPlugin.CURRENT_PRICE_FIELD]?.jsonPrimitive?.double!!)],
+							locale["commands.command.broker.priceBeforeMarketClose", plugin.convertReaisToSonhos(stock[LoriBrokerPlugin.CURRENT_PRICE_FIELD]?.jsonPrimitive?.double!!)],
 							true
 					)
 				else
 					embed.addField(
 							"${Emotes.ONLINE} `${stock["short_name"]?.jsonPrimitive?.content}` ($tickerName) | ${"%.2f".format(changePercentage)}%",
-							"""${locale["commands.economy.broker.buyPrice", buyingPrice]}
-							  |${locale["commands.economy.broker.sellPrice", sellingPrice]}
+							"""${locale["commands.command.broker.buyPrice", buyingPrice]}
+							  |${locale["commands.command.broker.sellPrice", sellingPrice]}
 							""".trimMargin(),
 							true
 					)

--- a/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerPortfolioCommand.kt
+++ b/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerPortfolioCommand.kt
@@ -11,7 +11,7 @@ import org.jetbrains.exposed.sql.select
 
 class BrokerPortfolioCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractCommandBase(plugin.loritta, plugin.aliases.flatMap { listOf("$it portfolio", "$it portfólio", "$it p") }, CommandCategory.ECONOMY) {
 	override fun command() = create {
-		localizedDescription("commands.economy.brokerPortfolio.description")
+		localizedDescription("commands.command.brokerportfolio.description")
 
 		executesDiscord {
 			// This may seem extremely dumb
@@ -31,7 +31,7 @@ class BrokerPortfolioCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 			}
 
 			val embed = plugin.getBaseEmbed()
-					.setTitle("${Emotes.LORI_STONKS} ${locale["commands.economy.brokerPortfolio.title"]}")
+					.setTitle("${Emotes.LORI_STONKS} ${locale["commands.command.brokerportfolio.title"]}")
 
 			for ((tickerId, totalSpent) in totalStockExpensesById) {
 				val ticker = plugin.tradingApi
@@ -57,9 +57,9 @@ class BrokerPortfolioCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 				embed.addField(
 						"$emoji `${ticker["short_name"]?.jsonPrimitive?.content}` ($tickerName) | ${"%.2f".format(changePercentage)}%",
 						locale[
-								"commands.economy.brokerPortfolio.youHaveStocksInThisTicker",
+								"commands.command.brokerportfolio.youHaveStocksInThisTicker",
 								stockCount,
-								locale["commands.economy.broker.stocks.${if (stockCount == 1L) "one" else "multiple"}"],
+								locale["commands.command.broker.stocks.${if (stockCount == 1L) "one" else "multiple"}"],
 								totalSpent,
 								totalGainsIfSoldNow,
 								diff.let { if (it > 0) "+$it" else it.toString() }

--- a/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerSellStockCommand.kt
+++ b/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerSellStockCommand.kt
@@ -26,7 +26,7 @@ class BrokerSellStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 	}
 
 	override fun command() = create {
-		localizedDescription("commands.economy.brokerSell.description")
+		localizedDescription("commands.command.brokersell.description")
 
 		arguments {
 			argument(ArgumentType.TEXT) {}
@@ -41,17 +41,17 @@ class BrokerSellStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 					?: explainAndExit()
 
 			if (!plugin.validStocksCodes.any { it == this.args[0] })
-				fail(locale["commands.economy.broker.invalidTickerId", locale["commands.economy.brokerBuy.baseExample", serverConfig.commandPrefix]])
+				fail(locale["commands.command.broker.invalidTickerId", locale["commands.command.brokerbuy.baseExample", serverConfig.commandPrefix]])
 
 			val ticker = plugin.tradingApi
 					.getOrRetrieveTicker(tickerId, listOf(LoriBrokerPlugin.CURRENT_PRICE_FIELD, "description"))
 
 			if (ticker["current_session"]!!.jsonPrimitive.content != LoriBrokerPlugin.MARKET)
-				fail(locale["commands.economy.broker.outOfSession"])
+				fail(locale["commands.command.broker.outOfSession"])
 
 			val mutex = plugin.mutexes.getOrPut(user.idLong, { Mutex() })
 			if (mutex.isLocked)
-				fail(locale["commands.economy.broker.alreadyExecutingAction"])
+				fail(locale["commands.command.broker.alreadyExecutingAction"])
 
 			var quantity = this.args.getOrNull(1) ?: "1"
 
@@ -69,7 +69,7 @@ class BrokerSellStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 					?: GenericReplies.invalidNumber(this, quantity)
 
 			if (0 >= number)
-				fail(locale["commands.economy.brokerSell.zeroValue"], Constants.ERROR)
+				fail(locale["commands.command.brokersell.zeroValue"], Constants.ERROR)
 
 			mutex.withLock {
 				val selfStocks = loritta.newSuspendedTransaction {
@@ -79,7 +79,7 @@ class BrokerSellStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 				}
 
 				if (number > selfStocks.size)
-					fail(locale["commands.economy.brokerSell.notEnoughStocks", tickerId])
+					fail(locale["commands.command.brokersell.notEnoughStocks", tickerId])
 
 				val stocksThatWillBeSold = selfStocks.take(number.toInt())
 				val howMuchWillBePaidToTheUser = plugin.convertToSellingPrice(
@@ -98,7 +98,7 @@ class BrokerSellStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 					}.count() == selfStocks.size.toLong()
 
 					if (!canBeExecuted)
-						fail(locale["commands.economy.brokerSell.boughtStocksWhileSelling"])
+						fail(locale["commands.command.brokersell.boughtStocksWhileSelling"])
 
 					BoughtStocks.deleteWhere {
 						BoughtStocks.id inList stocksThatWillBeSold.map { it[BoughtStocks.id] }
@@ -117,29 +117,29 @@ class BrokerSellStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 				reply(
 						LorittaReply(
 								locale[
-										"commands.economy.brokerSell.successfullySold",
+										"commands.command.brokersell.successfullySold",
 										stocksThatWillBeSold.size,
-										locale["commands.economy.broker.stocks.${if (stocksThatWillBeSold.size == 1) "one" else "multiple"}"],
+										locale["commands.command.broker.stocks.${if (stocksThatWillBeSold.size == 1) "one" else "multiple"}"],
 										tickerId,
 										when {
 											totalEarnings == 0L -> {
 												locale[
-														"commands.economy.brokerSell.successfullySoldNeutral"
+														"commands.command.brokersell.successfullySoldNeutral"
 												]
 											}
 											totalEarnings > 0L -> {
 												locale[
-														"commands.economy.brokerSell.successfullySoldProfit",
+														"commands.command.brokersell.successfullySoldProfit",
 														abs(howMuchWillBePaidToTheUser),
 														abs(totalEarnings)
 												]
 											}
 											else -> {
 												locale[
-														"commands.economy.brokerSell.successfullySoldLoss",
+														"commands.command.brokersell.successfullySoldLoss",
 														abs(howMuchWillBePaidToTheUser),
 														abs(totalEarnings),
-														locale["commands.economy.broker.portfolioExample", serverConfig.commandPrefix]
+														locale["commands.command.broker.portfolioExample", serverConfig.commandPrefix]
 												]
 											}
 										}

--- a/loritta-plugins/lori-guild-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/loriguildstuff/commands/FastBanCommand.kt
+++ b/loritta-plugins/lori-guild-stuff/src/main/kotlin/net/perfectdreams/loritta/plugin/loriguildstuff/commands/FastBanCommand.kt
@@ -21,7 +21,7 @@ object FastBanCommand {
             "bob" to "Imagine fazer spam dizendo que não é para fazer spam."
     )
 
-    fun create(loritta: LorittaDiscord) = discordCommand(loritta, listOf("b", "fastban"), CommandCategory.ADMIN) {
+    fun create(loritta: LorittaDiscord) = discordCommand(loritta, listOf("b", "fastban"), CommandCategory.MODERATION) {
         this.hideInHelp = true
         this.commandCheckFilter {lorittaMessageEvent, _, _, _, _ ->
             lorittaMessageEvent.guild?.idLong == 297732013006389252L

--- a/loritta-plugins/mal-commands/src/main/kotlin/net/perfectdreams/loritta/plugin/malcommands/commands/MalAnimeCommand.kt
+++ b/loritta-plugins/mal-commands/src/main/kotlin/net/perfectdreams/loritta/plugin/malcommands/commands/MalAnimeCommand.kt
@@ -12,7 +12,7 @@ import net.perfectdreams.loritta.plugin.malcommands.util.MalConstants.MAL_COLOR
 import net.perfectdreams.loritta.plugin.malcommands.util.MalUtils
 
 class MalAnimeCommand(val m: MalCommandsPlugin) : DiscordAbstractCommandBase(m.loritta, listOf("malanime", "anime"), CommandCategory.ANIME) {
-    private val LOCALE_PREFIX = "commands.anime.mal.anime"
+    private val LOCALE_PREFIX = "commands.command.mal.anime"
     private val logger = KotlinLogging.logger { }
 
     override fun command() = create {

--- a/loritta-plugins/minecraft-stuff/src/main/kotlin/net/perfectdreams/loritta/commands/minecraft/McSignCommand.kt
+++ b/loritta-plugins/minecraft-stuff/src/main/kotlin/net/perfectdreams/loritta/commands/minecraft/McSignCommand.kt
@@ -16,8 +16,8 @@ import java.io.File
 
 class McSignCommand(val m: MinecraftStuff) : DiscordAbstractCommandBase(m.loritta, listOf("mcsign", "mcplaca"), CommandCategory.MINECRAFT) {
 	override fun command() = create {
-		localizedDescription("commands.minecraft.mcsign.description")
-		localizedExamples("commands.minecraft.mcsign.examples")
+		localizedDescription("commands.command.mcsign.description")
+		localizedExamples("commands.command.mcsign.examples")
 
 		usage {
 			argument(ArgumentType.TEXT) {}

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/ArtCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/ArtCommand.kt
@@ -7,7 +7,7 @@ class ArtCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("art", "arte"),
 		1,
-		"commands.images.art.description",
+		"commands.command.art.description",
 		"/api/v1/images/art",
 		"art.png"
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/AtaCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/AtaCommand.kt
@@ -7,7 +7,7 @@ class AtaCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("ata", "monicaata", "mônicaata"),
 		1,
-		"commands.images.ata.description",
+		"commands.command.ata.description",
 		"/api/v1/images/monica-ata",
 		"ata.png"
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/AttackOnHeartCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/AttackOnHeartCommand.kt
@@ -8,7 +8,7 @@ class AttackOnHeartCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("attackonheart"),
 		1,
-		"commands.videos.attackonheart.description",
+		"commands.command.attackonheart.description",
 		"/api/v1/videos/attack-on-heart",
 		"attack_on_heart.mp4",
 		sendTypingStatus = true,

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BobBurningPaperCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BobBurningPaperCommand.kt
@@ -7,7 +7,7 @@ class BobBurningPaperCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("bobburningpaper", "bobpaperfire", "bobfire", "bobpapelfogo", "bobfogo"),
 		1,
-		"commands.images.bobfire.description",
+		"commands.command.bobfire.description",
 		"/api/v1/images/bob-burning-paper",
 		"bobfire.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BolsoDrakeCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BolsoDrakeCommand.kt
@@ -7,7 +7,7 @@ class BolsoDrakeCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("bolsodrake"),
 		2,
-		"commands.images.bolsodrake.description",
+		"commands.command.bolsodrake.description",
 		"/api/v1/images/bolso-drake",
 		"bolsodrake.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BolsoFrameCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BolsoFrameCommand.kt
@@ -7,7 +7,7 @@ class BolsoFrameCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("bolsoframe", "bolsonaroframe", "bolsoquadro", "bolsonaroquadro"),
 		1,
-		"commands.images.bolsoframe.description",
+		"commands.command.bolsoframe.description",
 		"/api/v1/images/bolso-frame",
 		"bolsoframe.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/Bolsonaro2Command.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/Bolsonaro2Command.kt
@@ -7,7 +7,7 @@ class Bolsonaro2Command(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("bolsonaro2", "bolsonarotv2"),
 		1,
-		"commands.images.bolsonaro.description",
+		"commands.command.bolsonaro.description",
 		"/api/v1/images/bolsonaro2",
 		"bolsonaro_tv2.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BolsonaroCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BolsonaroCommand.kt
@@ -7,7 +7,7 @@ class BolsonaroCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("bolsonaro", "bolsonarotv"),
 		1,
-		"commands.images.bolsonaro.description",
+		"commands.command.bolsonaro.description",
 		"/api/v1/images/bolsonaro",
 		"bolsonaro_tv.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BriggsCoverCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BriggsCoverCommand.kt
@@ -7,7 +7,7 @@ class BriggsCoverCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("briggscover", "coverbriggs", "capabriggs", "briggscapa"),
 		1,
-		"commands.images.briggscover.description",
+		"commands.command.briggscover.description",
 		"/api/v1/images/briggs-cover",
 		"briggs_capa.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BuckShirtCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/BuckShirtCommand.kt
@@ -7,7 +7,7 @@ class BuckShirtCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("buckshirt", "buckcamisa"),
 		1,
-		"commands.images.buckshirt.description",
+		"commands.command.buckshirt.description",
 		"/api/v1/images/buck-shirt",
 		"buck_shirt.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/CanellaDvdCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/CanellaDvdCommand.kt
@@ -7,7 +7,7 @@ class CanellaDvdCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("canelladvd", "matheuscanelladvd", "canellacover", "matheuscanelladvd"),
 		1,
-		"commands.images.canelladvd.description",
+		"commands.command.canelladvd.description",
 		"/api/v1/images/canella-dvd",
 		"canella_dvd.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/CarlyAaahCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/CarlyAaahCommand.kt
@@ -8,7 +8,7 @@ class CarlyAaahCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("carlyaaah"),
 		1,
-		"commands.videos.carlyaaah.description",
+		"commands.command.carlyaaah.description",
 		"/api/v1/videos/carly-aaah",
 		"carly_aaah.mp4",
 		sendTypingStatus = true,

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/ChicoAtaCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/ChicoAtaCommand.kt
@@ -7,7 +7,7 @@ class ChicoAtaCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("chicoata"),
 		1,
-		"commands.images.chicoata.description",
+		"commands.command.chicoata.description",
 		"/api/v1/images/chico-ata",
 		"chico_ata.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/DrakeCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/DrakeCommand.kt
@@ -7,7 +7,7 @@ class DrakeCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("drake"),
 		2,
-		"commands.images.drake.description",
+		"commands.command.drake.description",
 		"/api/v1/images/drake",
 		"drake.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/EdnaldoBandeiraCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/EdnaldoBandeiraCommand.kt
@@ -7,7 +7,7 @@ class EdnaldoBandeiraCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("ednaldobandeira"),
 		1,
-		"commands.images.ednaldobandeira.description",
+		"commands.command.ednaldobandeira.description",
 		"/api/v1/images/ednaldo-bandeira",
 		"ednaldo_bandeira.png"
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/EdnaldoTvCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/EdnaldoTvCommand.kt
@@ -7,7 +7,7 @@ class EdnaldoTvCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("ednaldotv"),
 		1,
-		"commands.images.ednaldotv.description",
+		"commands.command.ednaldotv.description",
 		"/api/v1/images/ednaldo-tv",
 		"ednaldo_tv.png"
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/GessyAtaCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/GessyAtaCommand.kt
@@ -7,7 +7,7 @@ class GessyAtaCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("gessyata"),
 		1,
-		"commands.images.gessyata.description",
+		"commands.command.gessyata.description",
 		"/api/v1/images/gessy-ata",
 		"gessy_ata.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/LoriAtaCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/LoriAtaCommand.kt
@@ -7,7 +7,7 @@ class LoriAtaCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("loriata"),
 		1,
-		"commands.images.loriata.description",
+		"commands.command.loriata.description",
 		"/api/v1/images/lori-ata",
 		"lori_ata.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/LoriDrakeCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/LoriDrakeCommand.kt
@@ -7,7 +7,7 @@ class LoriDrakeCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("loridrake"),
 		2,
-		"commands.images.loridrake.description",
+		"commands.command.loridrake.description",
 		"/api/v1/images/lori-drake",
 		"lori_drake.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/LoriSignCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/LoriSignCommand.kt
@@ -7,7 +7,7 @@ class LoriSignCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("lorisign", "lorittasign", "loriplaca", "lorittaplaca"),
 		1,
-		"commands.images.lorisign.description",
+		"commands.command.lorisign.description",
 		"/api/v1/images/lori-sign",
 		"lori_sign.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/PassingPaperCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/PassingPaperCommand.kt
@@ -7,7 +7,7 @@ class PassingPaperCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("passingpaper", "bilhete", "quizkid"),
 		1,
-		"commands.images.passingpaper.description",
+		"commands.command.passingpaper.description",
 		"/api/v1/images/passing-paper",
 		"passing_paper.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/PepeDreamCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/PepeDreamCommand.kt
@@ -7,7 +7,7 @@ class PepeDreamCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("pepedream", "sonhopepe", "pepesonho"),
 		1,
-		"commands.images.pepedream.description",
+		"commands.command.pepedream.description",
 		"/api/v1/images/pepe-dream",
 		"pepe_dream.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/PetPetCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/PetPetCommand.kt
@@ -7,7 +7,7 @@ class PetPetCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("petpet"),
 		1,
-		"commands.images.petpet.description",
+		"commands.command.petpet.description",
 		"/api/v1/images/pet-pet",
 		"petpet.gif"
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/QuadroCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/QuadroCommand.kt
@@ -7,7 +7,7 @@ class QuadroCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("quadro", "frame", "picture", "wolverine"),
 		1,
-		"commands.images.wolverine.description",
+		"commands.command.wolverine.description",
 		"/api/v1/images/wolverine-frame",
 		"wolverine_frame.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/RipTvCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/RipTvCommand.kt
@@ -7,7 +7,7 @@ class RipTvCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("riptv"),
 		1,
-		"commands.images.riptv.description",
+		"commands.command.riptv.description",
 		"/api/v1/images/rip-tv",
 		"rip_tv.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/RomeroBrittoCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/RomeroBrittoCommand.kt
@@ -7,7 +7,7 @@ class RomeroBrittoCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("romerobritto", "pintura", "painting"),
 		1,
-		"commands.images.romerobritto.description",
+		"commands.command.romerobritto.description",
 		"/api/v1/images/romero-britto",
 		"romero_britto.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/SAMCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/SAMCommand.kt
@@ -12,7 +12,7 @@ class SAMCommand(m: RosbifePlugin) : ImageAbstractCommandBase(
 		listOf("sam", "southamericamemes")
 ) {
 	override fun command() = create {
-		localizedDescription("commands.images.sam.description")
+		localizedDescription("commands.command.sam.description")
 		localizedExamples(Command.SINGLE_IMAGE_EXAMPLES_KEY)
 
 		usage {

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/StudiopolisTvCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/StudiopolisTvCommand.kt
@@ -7,7 +7,7 @@ class StudiopolisTvCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("studiopolistv", "studiopolis"),
 		1,
-		"commands.images.studiopolistv.description",
+		"commands.command.studiopolistv.description",
 		"/api/v1/images/studiopolis-tv",
 		"studiopolis_tv.png",
 )

--- a/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/SustoCommand.kt
+++ b/loritta-plugins/rosbife/src/commonMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/SustoCommand.kt
@@ -7,7 +7,7 @@ class SustoCommand(m: RosbifePlugin) : GabrielaImageServerCommandBase(
 		m.loritta,
 		listOf("scared", "fright", "susto"),
 		1,
-		"commands.images.susto.description",
+		"commands.command.susto.description",
 		"/api/v1/images/lori-scared",
 		"loritta_susto.png",
 )

--- a/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/CocieloChavesCommand.kt
+++ b/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/CocieloChavesCommand.kt
@@ -28,8 +28,8 @@ class CocieloChavesCommand(m: RosbifePlugin) : DiscordAbstractCommandBase(
 			.asMap()
 
 	override fun command() = create {
-		localizedDescription("commands.videos.cocielochaves.description")
-		localizedExamples("commands.videos.cocielochaves.examples")
+		localizedDescription("commands.command.cocielochaves.description")
+		localizedExamples("commands.command.cocielochaves.examples")
 
 		sendTypingStatus = true
 

--- a/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/CortesFlowCommand.kt
+++ b/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/CortesFlowCommand.kt
@@ -25,8 +25,8 @@ class CortesFlowCommand(
         CommandCategory.IMAGES
 ) {
     override fun command() = create {
-        localizedDescription("commands.images.cortesflow.description")
-        localizedExamples("commands.images.cortesflow.examples")
+        localizedDescription("commands.command.cortesflow.description")
+        localizedExamples("commands.command.cortesflow.examples")
 
         needsToUploadFiles = true
 
@@ -46,15 +46,15 @@ class CortesFlowCommand(
                         .entries
                         .sortedByDescending { it.value.size }
                 val embed = EmbedBuilder()
-                        .setTitle("${Emotes.FLOW_PODCAST} ${locale["commands.images.cortesflow.embedTitle"]}")
+                        .setTitle("${Emotes.FLOW_PODCAST} ${locale["commands.command.cortesflow.embedTitle"]}")
                         .setDescription(
                                 locale.getList(
-                                        "commands.images.cortesflow.embedDescription",
-                                        locale["commands.images.cortesflow.howToUseExample", serverConfig.commandPrefix],
-                                        locale["commands.images.cortesflow.commandExample", serverConfig.commandPrefix]
+                                        "commands.command.cortesflow.embedDescription",
+                                        locale["commands.command.cortesflow.howToUseExample", serverConfig.commandPrefix],
+                                        locale["commands.command.cortesflow.commandExample", serverConfig.commandPrefix]
                                 ).joinToString("\n")
                         )
-                        .setFooter(locale["commands.images.cortesflow.findOutThumbnailSource"], "https://yt3.ggpht.com/a/AATXAJwhhX5JXoYvdDwDI56fQfTDinfs21vzivC-DBW6=s88-c-k-c0x00ffffff-no-rj")
+                        .setFooter(locale["commands.command.cortesflow.findOutThumbnailSource"], "https://yt3.ggpht.com/a/AATXAJwhhX5JXoYvdDwDI56fQfTDinfs21vzivC-DBW6=s88-c-k-c0x00ffffff-no-rj")
                         .setColor(Color.BLACK)
 
                 for ((_, value) in availableGroupedBy) {
@@ -62,7 +62,7 @@ class CortesFlowCommand(
                             value.first().jsonObject["participantDisplayName"]!!.jsonPrimitive.content,
                             value.joinToString {
                                 locale[
-                                        "commands.images.cortesflow.thumbnailSelection",
+                                        "commands.command.cortesflow.thumbnailSelection",
                                         it.jsonObject["path"]!!.jsonPrimitive.content.removePrefix("/api/v1/images/cortes-flow/"),
                                         it.jsonObject["source"]!!.jsonPrimitive.content
                                 ]
@@ -78,7 +78,7 @@ class CortesFlowCommand(
             }
 
             if (args.size == 1)
-                fail(locale["commands.images.cortesflow.youNeedToAddText"])
+                fail(locale["commands.command.cortesflow.youNeedToAddText"])
 
             val type = args.getOrNull(0)
             val string = args
@@ -96,7 +96,7 @@ class CortesFlowCommand(
             }
 
             if (response.status == HttpStatusCode.NotFound)
-                fail(locale["commands.images.cortesflow.unknownType", serverConfig.commandPrefix])
+                fail(locale["commands.command.cortesflow.unknownType", serverConfig.commandPrefix])
 
             sendFile(response.receive<ByteArray>(), "cortes_flow.jpg")
         }

--- a/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/MorrePragaCommand.kt
+++ b/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/MorrePragaCommand.kt
@@ -16,7 +16,7 @@ import java.io.File
 
 class MorrePragaCommand(m: RosbifePlugin) : ImageAbstractCommandBase(m.loritta, listOf("dieplague", "morrepraga")) {
 	override fun command() = create {
-		localizedDescription("commands.images.morrepraga.description")
+		localizedDescription("commands.command.morrepraga.description")
 		localizedExamples(Command.SINGLE_IMAGE_EXAMPLES_KEY)
 
 		usage {
@@ -45,14 +45,14 @@ class MorrePragaCommand(m: RosbifePlugin) : ImageAbstractCommandBase(m.loritta, 
 
 			ImageUtils.drawCenteredString(
 				graphics,
-				locale["commands.images.morrepraga.topText"],
+				locale["commands.command.morrepraga.topText"],
 				Rectangle(25, 38, 502, 132),
 				graphics.font
 			)
 
 			ImageUtils.drawCenteredString(
 				graphics,
-				locale["commands.images.morrepraga.bottomText"],
+				locale["commands.command.morrepraga.bottomText"],
 				Rectangle(43, 480, 468, 139),
 				graphics.font
 			)

--- a/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/TerminatorCommand.kt
+++ b/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/TerminatorCommand.kt
@@ -17,8 +17,8 @@ class TerminatorCommand(m: RosbifePlugin) : ImageAbstractCommandBase(
 		listOf("terminator", "animeterminator", "terminatoranime")
 ) {
 	override fun command() = create {
-		localizedDescription("commands.images.terminator.description")
-		localizedExamples("commands.images.terminator.examples")
+		localizedDescription("commands.command.terminator.description")
+		localizedExamples("commands.command.terminator.examples")
 
 		usage {
 			argument(ArgumentType.TEXT) {}

--- a/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/ToBeContinuedCommand.kt
+++ b/loritta-plugins/rosbife/src/jvmMain/kotlin/net/perfectdreams/loritta/plugin/rosbife/commands/ToBeContinuedCommand.kt
@@ -10,7 +10,7 @@ import java.awt.image.BufferedImage
 
 class ToBeContinuedCommand(m: RosbifePlugin) : ImageAbstractCommandBase(m.loritta, listOf("tobecontinued")) {
 	override fun command() = create {
-		localizedDescription("commands.images.tobecontinued.description")
+		localizedDescription("commands.command.tobecontinued.description")
 		localizedExamples(Command.SINGLE_IMAGE_EXAMPLES_KEY)
 
 		usage {

--- a/loritta-website/spicy-morenitta/src/main/kotlin/net/perfectdreams/spicymorenitta/SpicyMorenitta.kt
+++ b/loritta-website/spicy-morenitta/src/main/kotlin/net/perfectdreams/spicymorenitta/SpicyMorenitta.kt
@@ -223,8 +223,8 @@ class SpicyMorenitta : Logging {
 				if (currentRoute.requiresLocales) {
 					deferred[0].await()
 
-					debug("Locale test: ${locale["commands.images.drawnword.description"]}")
-					debug("Locale test: ${locale["commands.fun.ship.bribeLove", ":3"]}")
+					debug("Locale test: ${locale["commands.command.drawnword.description"]}")
+					debug("Locale test: ${locale["commands.command.ship.bribeLove", ":3"]}")
 				}
 				if (currentRoute.requiresUserIdentification)
 					deferred[1].await()

--- a/loritta-website/spicy-morenitta/src/main/kotlin/net/perfectdreams/spicymorenitta/routes/guilds/dashboard/ModerationConfigRoute.kt
+++ b/loritta-website/spicy-morenitta/src/main/kotlin/net/perfectdreams/spicymorenitta/routes/guilds/dashboard/ModerationConfigRoute.kt
@@ -108,7 +108,7 @@ class ModerationConfigRoute(val m: SpicyMorenitta) : UpdateNavbarSizePostRender(
 					for (entry in ServerConfig.PunishmentAction.values()) {
 						option {
 							value = entry.name
-							+locale["commands.moderation.${entry.name.toLowerCase()}.punishAction"]
+							+locale["commands.command.${entry.name.toLowerCase()}.punishAction"]
 						}
 					}
 				}
@@ -154,7 +154,7 @@ class ModerationConfigRoute(val m: SpicyMorenitta) : UpdateNavbarSizePostRender(
 					locale.buildAsHtml(locale["modules.moderation.specificMessagesForPunishment.messageThatWillBeShown"], { num ->
 						if (num == 0)
 							span {
-								+locale["commands.moderation.${action.name.toLowerCase()}.punishAction"]
+								+locale["commands.command.${action.name.toLowerCase()}.punishAction"]
 							}
 					}) { str ->
 						+ str


### PR DESCRIPTION
```kotlin
            // Before, all commands locales were split up into different files, based on the category, example:
            // commands-discord.yml
            // commands:
            //   discord:
            //     userinfo:
            //       description: "owo"
            //
            // However, this had a issue that, if we wanted to move commands from a category to another, we would need to move the locales from
            // the file AND change the locale key, so, if we wanted to change a command category, that would also need to change all locale keys
            // to match. I think that was not a great thing to have.
            //
            // I thought that maybe we could remove the category from the command itself and keep it as "command:" or something, like this:
            // commands-discord.yml
            // commands:
            //   command:
            //     userinfo:
            //       description: "owo"
            //
            // This avoids the issue of needing to change the locale keys in the source code, but we still need to move stuff around if a category changes!
            // (due to the file name)
            // This also has a issue that Crowdin "forgets" who did the translation because the file changed, which is very undesirable.
            //
            // I thought that all the command keys could be in the same file and, while that would work, it would become a mess.
            //
            // So I decided to spice things up and split every command locale into different files, so, as an example:
            // userinfo.yml
            // commands:
            //   discord:
            //     userinfo:
            //       description: "owo"
            //
            // But that's boring, let's spice it up even more!
            // userinfo.yml
            // description: "owo"
            //
            // And, when loading the file, the prefix "commands.command.FileNameHere." is automatically appended to the key!
            // This fixes our previous issues:
            // * No need to change the source code on category changes, because the locale key doesn't has any category related stuff
            // * No need to change locales to other files due to category changes
            // * More tidy
            // * If a command is removed from Loritta, removing the locales is a breeze because you just need to delete the locale key related to the command!
            //
            // Very nice :3
            //
            // So, first, we will check if the commands folder exist and, if it is, we are going to load all the files within the folder and apply a
            // auto prefix to it.
```