### PR TITLE
Refactor sonhos add/take + sonhos transactions

### DIFF
--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/LigarCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/economy/LigarCommand.kt
@@ -4,13 +4,13 @@ import com.mrpowergamerbr.loritta.Loritta.Companion.RANDOM
 import com.mrpowergamerbr.loritta.commands.AbstractCommand
 import com.mrpowergamerbr.loritta.commands.CommandContext
 import com.mrpowergamerbr.loritta.utils.Constants
-import net.perfectdreams.loritta.api.messages.LorittaReply
 import com.mrpowergamerbr.loritta.utils.locale.BaseLocale
 import com.mrpowergamerbr.loritta.utils.loritta
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import net.perfectdreams.loritta.api.commands.CommandCategory
+import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.tables.BomDiaECiaWinners
 import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
@@ -47,11 +47,9 @@ class LigarCommand : AbstractCommand("ligar", category = CommandCategory.ECONOMY
 				}
 
 				loritta.newSuspendedTransaction {
-					profile.takeSonhosNested(75)
-					PaymentUtils.addToTransactionLogNested(
-							75,
-							SonhosPaymentReason.BOM_DIA_E_CIA,
-							givenBy = context.userHandle.idLong
+					profile.takeSonhosAndAddToTransactionLogNested(
+						75,
+						SonhosPaymentReason.BOM_DIA_E_CIA
 					)
 				}
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/MarryCommand.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/commands/vanilla/social/MarryCommand.kt
@@ -11,7 +11,6 @@ import com.mrpowergamerbr.loritta.utils.loritta
 import com.mrpowergamerbr.loritta.utils.onReactionAdd
 import net.perfectdreams.loritta.api.commands.CommandCategory
 import net.perfectdreams.loritta.api.messages.LorittaReply
-import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 
 class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.SOCIAL) {
@@ -198,19 +197,16 @@ class MarryCommand : AbstractCommand("marry", listOf("casar"), CommandCategory.S
 						profile.marriage = newMarriage
 						proposeToProfile.marriage = newMarriage
 
-						profile.takeSonhosNested(splitCost.toLong())
-						proposeToProfile.takeSonhosNested(splitCost.toLong())
+						val splitCostAsLong = splitCost.toLong()
 
-						PaymentUtils.addToTransactionLogNested(
-								splitCost.toLong(),
-								SonhosPaymentReason.MARRIAGE,
-								givenBy = profile.id.value
+						profile.takeSonhosAndAddToTransactionLogNested(
+							splitCostAsLong,
+							SonhosPaymentReason.MARRIAGE
 						)
 
-						PaymentUtils.addToTransactionLogNested(
-								splitCost.toLong(),
-								SonhosPaymentReason.MARRIAGE,
-								givenBy = proposeToProfile.id.value
+						proposeToProfile.takeSonhosAndAddToTransactionLogNested(
+							splitCostAsLong,
+							SonhosPaymentReason.MARRIAGE
 						)
 					}
 

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/dao/Profile.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/dao/Profile.kt
@@ -6,6 +6,7 @@ import com.mrpowergamerbr.loritta.utils.loritta
 import mu.KotlinLogging
 import net.perfectdreams.loritta.tables.BannedUsers
 import net.perfectdreams.loritta.utils.PaymentUtils
+import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import net.perfectdreams.loritta.utils.TakingMoreSonhosThanAllowedException
 import org.jetbrains.exposed.dao.Entity
 import org.jetbrains.exposed.dao.EntityClass
@@ -149,6 +150,62 @@ class Profile(id: EntityID<Long>) : Entity<Long>(id) {
 		// If everything went well, refresh the current DAO
 		if (refreshOnSuccess)
 			this@Profile.refresh()
+	}
+
+	/**
+	 * Add sonhos and adds to the transaction log
+	 */
+	fun addSonhosAndAddToTransactionLogNested(
+		quantity: Long,
+		reason: SonhosPaymentReason,
+		givenAtMillis: Long = System.currentTimeMillis(),
+		refreshBeforeAction: Boolean = true,
+		checksBeforeAction: ((Profile) -> (Boolean))? = null,
+		refreshOnSuccess: Boolean = true
+	) {
+		addSonhosNested(
+			quantity,
+			refreshBeforeAction,
+			checksBeforeAction,
+			refreshOnSuccess
+		)
+
+		PaymentUtils.addToTransactionLogNested(
+			quantity,
+			reason,
+			id.value,
+			null,
+			givenAtMillis
+		)
+	}
+
+	/**
+	 * Takes sonhos and adds to the transaction log
+	 */
+	fun takeSonhosAndAddToTransactionLogNested(
+		quantity: Long,
+		reason: SonhosPaymentReason,
+		givenAtMillis: Long = System.currentTimeMillis(),
+		refreshBeforeAction: Boolean = true,
+		failIfQuantityIsSmallerThanWhatUserHas: Boolean = true,
+		checksBeforeAction: ((Profile) -> (Boolean))? = null,
+		refreshOnSuccess: Boolean = true
+	) {
+		takeSonhosNested(
+			quantity,
+			refreshBeforeAction,
+			failIfQuantityIsSmallerThanWhatUserHas,
+			checksBeforeAction,
+			refreshOnSuccess
+		)
+
+		PaymentUtils.addToTransactionLogNested(
+			quantity,
+			reason,
+			null,
+			id.value,
+			givenAtMillis
+		)
 	}
 
 	suspend fun getProfileBackground() = loritta.getUserProfileBackground(userId)

--- a/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/threads/RaffleThread.kt
+++ b/loritta-discord/src/main/java/com/mrpowergamerbr/loritta/threads/RaffleThread.kt
@@ -12,7 +12,6 @@ import mu.KotlinLogging
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.MessageBuilder
 import net.perfectdreams.loritta.utils.Emotes
-import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import net.perfectdreams.loritta.utils.UserPremiumPlans
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -94,12 +93,10 @@ class RaffleThread : Thread("Raffle Thread") {
 			val lorittaProfile = loritta.getOrCreateLorittaProfile(winnerId)
 			logger.info("$lastWinnerId ganhou $lastWinnerPrize sonhos ($moneyWithoutTaxes without taxes; antes ele possuia ${lorittaProfile.money} sonhos) na Rifa!")
 
-			transaction(Databases.loritta){
-				lorittaProfile.addSonhosNested(money.toLong())
-				PaymentUtils.addToTransactionLogNested(
-						money.toLong(),
-						SonhosPaymentReason.RAFFLE,
-						receivedBy = winnerId.toLongOrNull()
+			transaction(Databases.loritta) {
+				lorittaProfile.addSonhosAndAddToTransactionLogNested(
+					money.toLong(),
+					SonhosPaymentReason.RAFFLE
 				)
 			}
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/PaymentUtils.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/utils/PaymentUtils.kt
@@ -87,18 +87,13 @@ object PaymentUtils {
                     val profile = loritta.getOrCreateLorittaProfile(entry.key)
                     loritta.newSuspendedTransaction {
                         logger.info { "Taking $totalQuantity sonhos from ${entry.key} due to chargeback" }
-                        // Take the sonhos
-                        profile.takeSonhosNested(
-                                totalQuantity,
-                                // Maybe the user was spending stuff while we were checking for their sonhos, so let's ignore negative money issues
-                                failIfQuantityIsSmallerThanWhatUserHas = false
-                        )
 
-                        // And don't forget to log it!
-                        addToTransactionLogNested(
-                                totalQuantity,
-                                SonhosPaymentReason.CHARGEBACK,
-                                givenBy = entry.key
+                        // Take the sonhos
+                        profile.takeSonhosAndAddToTransactionLogNested(
+                            totalQuantity,
+                            SonhosPaymentReason.CHARGEBACK,
+                            // Maybe the user was spending stuff while we were checking for their sonhos, so let's ignore negative money issues
+                            failIfQuantityIsSmallerThanWhatUserHas = false
                         )
                     }
                 }

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/economy/GetLoriDailyRewardRoute.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/economy/GetLoriDailyRewardRoute.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import mu.KotlinLogging
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
-import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.ServerPremiumPlans
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import net.perfectdreams.loritta.utils.UserPremiumPlans
@@ -392,11 +391,9 @@ class GetLoriDailyRewardRoute(loritta: LorittaDiscord) : RequiresAPIDiscordLogin
 					it[Dailies.email] = email
 				}
 
-				lorittaProfile.addSonhosNested(dailyPayout.toLong())
-				PaymentUtils.addToTransactionLogNested(
-						dailyPayout.toLong(),
-						SonhosPaymentReason.DAILY,
-						receivedBy = lorittaProfile.id.value
+				lorittaProfile.addSonhosAndAddToTransactionLogNested(
+					dailyPayout.toLong(),
+					SonhosPaymentReason.DAILY
 				)
 			}
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/economy/PostBuyDailyShopItemRoute.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/economy/PostBuyDailyShopItemRoute.kt
@@ -14,8 +14,13 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
-import net.perfectdreams.loritta.tables.*
-import net.perfectdreams.loritta.utils.PaymentUtils
+import net.perfectdreams.loritta.tables.BackgroundPayments
+import net.perfectdreams.loritta.tables.Backgrounds
+import net.perfectdreams.loritta.tables.DailyProfileShopItems
+import net.perfectdreams.loritta.tables.DailyShopItems
+import net.perfectdreams.loritta.tables.DailyShops
+import net.perfectdreams.loritta.tables.ProfileDesigns
+import net.perfectdreams.loritta.tables.ProfileDesignsPayments
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import net.perfectdreams.loritta.utils.config.FanArtArtist
 import net.perfectdreams.loritta.website.routes.api.v1.RequiresAPIDiscordLoginRoute
@@ -23,7 +28,11 @@ import net.perfectdreams.loritta.website.session.LorittaJsonWebSession
 import net.perfectdreams.loritta.website.utils.WebsiteUtils
 import net.perfectdreams.loritta.website.utils.extensions.respondJson
 import net.perfectdreams.temmiediscordauth.TemmieDiscordAuth
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import java.util.concurrent.TimeUnit
 
@@ -86,11 +95,9 @@ class PostBuyDailyShopItemRoute(loritta: LorittaDiscord) : RequiresAPIDiscordLog
 								)
 						)
 
-					profile.takeSonhosNested(cost.toLong())
-					PaymentUtils.addToTransactionLogNested(
-							cost.toLong(),
-							SonhosPaymentReason.BACKGROUND,
-							givenBy = profile.id.value
+					profile.takeSonhosAndAddToTransactionLogNested(
+						cost.toLong(),
+						SonhosPaymentReason.BACKGROUND
 					)
 
 					BackgroundPayments.insert {
@@ -110,11 +117,9 @@ class PostBuyDailyShopItemRoute(loritta: LorittaDiscord) : RequiresAPIDiscordLog
 
 						val creator = com.mrpowergamerbr.loritta.utils.loritta.getOrCreateLorittaProfile(discordId)
 
-						creator.addSonhosNested(creatorReceived)
-						PaymentUtils.addToTransactionLogNested(
-								creatorReceived,
-								SonhosPaymentReason.BACKGROUND,
-								receivedBy = creator.id.value
+						creator.addSonhosAndAddToTransactionLogNested(
+							creatorReceived,
+							SonhosPaymentReason.BACKGROUND
 						)
 					}
 				} else if (type == "profile-design") {
@@ -156,11 +161,9 @@ class PostBuyDailyShopItemRoute(loritta: LorittaDiscord) : RequiresAPIDiscordLog
 								)
 						)
 
-					profile.takeSonhosNested(cost.toLong())
-					PaymentUtils.addToTransactionLogNested(
+					profile.takeSonhosAndAddToTransactionLogNested(
 							cost.toLong(),
-							SonhosPaymentReason.PROFILE,
-							givenBy = profile.id.value
+							SonhosPaymentReason.PROFILE
 					)
 
 					ProfileDesignsPayments.insert {
@@ -180,11 +183,9 @@ class PostBuyDailyShopItemRoute(loritta: LorittaDiscord) : RequiresAPIDiscordLog
 
 						val creator = com.mrpowergamerbr.loritta.utils.loritta.getOrCreateLorittaProfile(discordId)
 
-						creator.addSonhosNested(creatorReceived)
-						PaymentUtils.addToTransactionLogNested(
-								creatorReceived,
-								SonhosPaymentReason.PROFILE,
-								receivedBy = creator.id.value
+						creator.addSonhosAndAddToTransactionLogNested(
+							creatorReceived,
+							SonhosPaymentReason.PROFILE
 						)
 					}
 				}

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/economy/PostTransferBalanceExternalRoute.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/economy/PostTransferBalanceExternalRoute.kt
@@ -1,14 +1,17 @@
 package net.perfectdreams.loritta.website.routes.api.v1.economy
 
-import com.github.salomonbrys.kotson.*
+import com.github.salomonbrys.kotson.double
+import com.github.salomonbrys.kotson.get
+import com.github.salomonbrys.kotson.jsonObject
+import com.github.salomonbrys.kotson.long
+import com.github.salomonbrys.kotson.string
 import com.google.gson.JsonParser
-import io.ktor.application.ApplicationCall
-import io.ktor.request.receiveText
+import io.ktor.application.*
+import io.ktor.request.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
-import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import net.perfectdreams.loritta.website.routes.api.v1.RequiresAPIAuthenticationRoute
 import net.perfectdreams.loritta.website.utils.extensions.respondJson
@@ -31,11 +34,9 @@ class PostTransferBalanceExternalRoute(loritta: LorittaDiscord) : RequiresAPIAut
 		val finalMoney = (garticos * transferRate)
 
 		loritta.newSuspendedTransaction {
-			profile.addSonhosNested(finalMoney.toLong())
-			PaymentUtils.addToTransactionLogNested(
-					finalMoney.toLong(),
-					SonhosPaymentReason.GARTICOS_TRANSFER,
-					receivedBy = profile.id.value
+			profile.addSonhosAndAddToTransactionLogNested(
+				finalMoney.toLong(),
+				SonhosPaymentReason.GARTICOS_TRANSFER
 			)
 		}
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/loritta/PostRaffleStatusRoute.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/loritta/PostRaffleStatusRoute.kt
@@ -60,7 +60,7 @@ class PostRaffleStatusRoute(loritta: LorittaDiscord) : RequiresAPIAuthentication
 
 			if (lorittaProfile.money >= requiredCount) {
 				loritta.newSuspendedTransaction {
-					lorittaProfile.addSonhosAndAddToTransactionLogNested(
+					lorittaProfile.takeSonhosAndAddToTransactionLogNested(
 						requiredCount,
 						SonhosPaymentReason.RAFFLE
 					)

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/loritta/PostRaffleStatusRoute.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/loritta/PostRaffleStatusRoute.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
-import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import net.perfectdreams.loritta.website.routes.api.v1.RequiresAPIAuthenticationRoute
 import net.perfectdreams.loritta.website.utils.extensions.respondJson
@@ -61,11 +60,9 @@ class PostRaffleStatusRoute(loritta: LorittaDiscord) : RequiresAPIAuthentication
 
 			if (lorittaProfile.money >= requiredCount) {
 				loritta.newSuspendedTransaction {
-					lorittaProfile.takeSonhosNested(requiredCount)
-					PaymentUtils.addToTransactionLogNested(
-							requiredCount,
-							SonhosPaymentReason.RAFFLE,
-							givenBy = lorittaProfile.id.value
+					lorittaProfile.addSonhosAndAddToTransactionLogNested(
+						requiredCount,
+						SonhosPaymentReason.RAFFLE
 					)
 				}
 

--- a/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/user/PatchProfileRoute.kt
+++ b/loritta-discord/src/main/java/net/perfectdreams/loritta/website/routes/api/v1/user/PatchProfileRoute.kt
@@ -1,29 +1,34 @@
 package net.perfectdreams.loritta.website.routes.api.v1.user
 
-import com.github.salomonbrys.kotson.*
+import com.github.salomonbrys.kotson.int
+import com.github.salomonbrys.kotson.jsonObject
+import com.github.salomonbrys.kotson.nullString
+import com.github.salomonbrys.kotson.obj
+import com.github.salomonbrys.kotson.string
 import com.google.gson.JsonParser
 import com.mrpowergamerbr.loritta.Loritta
 import com.mrpowergamerbr.loritta.dao.Background
 import com.mrpowergamerbr.loritta.dao.ProfileDesign
 import com.mrpowergamerbr.loritta.dao.ShipEffect
-import com.mrpowergamerbr.loritta.utils.*
+import com.mrpowergamerbr.loritta.utils.Constants
+import com.mrpowergamerbr.loritta.utils.isValidSnowflake
+import com.mrpowergamerbr.loritta.utils.lorittaShards
+import com.mrpowergamerbr.loritta.utils.toBufferedImage
 import com.mrpowergamerbr.loritta.website.LoriWebCode
 import com.mrpowergamerbr.loritta.website.WebsiteAPIException
-import io.ktor.application.ApplicationCall
-import io.ktor.http.HttpStatusCode
-import io.ktor.request.receiveText
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.request.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.perfectdreams.loritta.platform.discord.LorittaDiscord
 import net.perfectdreams.loritta.tables.BackgroundPayments
 import net.perfectdreams.loritta.tables.ProfileDesigns
 import net.perfectdreams.loritta.tables.ProfileDesignsPayments
-import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import net.perfectdreams.loritta.utils.UserPremiumPlans
 import net.perfectdreams.loritta.utils.extensions.readImage
 import net.perfectdreams.loritta.website.routes.api.v1.RequiresAPIDiscordLoginRoute
-import net.perfectdreams.loritta.website.routes.user.dashboard.ProfileListRoute
 import net.perfectdreams.loritta.website.session.LorittaJsonWebSession
 import net.perfectdreams.loritta.website.utils.WebsiteUtils
 import net.perfectdreams.loritta.website.utils.extensions.respondJson
@@ -90,11 +95,9 @@ class PatchProfileRoute(loritta: LorittaDiscord) : RequiresAPIDiscordLoginRoute(
 					this.expiresAt = System.currentTimeMillis() + Constants.ONE_WEEK_IN_MILLISECONDS
 				}
 
-				profile.takeSonhosNested(3000)
-				PaymentUtils.addToTransactionLogNested(
-						3000,
-						SonhosPaymentReason.SHIP_EFFECT,
-						givenBy = profile.id.value
+				profile.takeSonhosAndAddToTransactionLogNested(
+					3000,
+					SonhosPaymentReason.SHIP_EFFECT
 				)
 			}
 

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/GuessNumberCommand.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/GuessNumberCommand.kt
@@ -65,7 +65,7 @@ class GuessNumberCommand(plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
             } else {
                 loritta.newSuspendedTransaction {
                     profile.takeSonhosAndAddToTransactionLogNested(
-                        VICTORY_PRIZE,
+                        LOSE_PRIZE,
                         SonhosPaymentReason.GUESS_NUMBER,
                     )
                 }

--- a/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/GuessNumberCommand.kt
+++ b/loritta-plugins/helping-hands/src/main/kotlin/net/perfectdreams/loritta/plugin/helpinghands/commands/GuessNumberCommand.kt
@@ -8,7 +8,6 @@ import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractComman
 import net.perfectdreams.loritta.plugin.helpinghands.HelpingHandsPlugin
 import net.perfectdreams.loritta.utils.Emotes
 import net.perfectdreams.loritta.utils.GenericReplies
-import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 
 class GuessNumberCommand(plugin: HelpingHandsPlugin) : DiscordAbstractCommandBase(
@@ -56,24 +55,18 @@ class GuessNumberCommand(plugin: HelpingHandsPlugin) : DiscordAbstractCommandBas
 
             if (won) {
                 loritta.newSuspendedTransaction {
-                    profile.addSonhosNested(VICTORY_PRIZE)
-
-                    PaymentUtils.addToTransactionLogNested(
-                            VICTORY_PRIZE,
-                            SonhosPaymentReason.GUESS_NUMBER,
-                            receivedBy = user.idLong
+                    profile.addSonhosAndAddToTransactionLogNested(
+                        VICTORY_PRIZE,
+                        SonhosPaymentReason.GUESS_NUMBER,
                     )
                 }
 
                 reply(locale["commands.command.guessnumber.youWin", VICTORY_PRIZE], Emotes.LORI_RICH)
             } else {
                 loritta.newSuspendedTransaction {
-                    profile.takeSonhosNested(LOSE_PRIZE)
-
-                    PaymentUtils.addToTransactionLogNested(
-                            LOSE_PRIZE,
-                            SonhosPaymentReason.GUESS_NUMBER,
-                            givenBy = user.idLong
+                    profile.takeSonhosAndAddToTransactionLogNested(
+                        VICTORY_PRIZE,
+                        SonhosPaymentReason.GUESS_NUMBER,
                     )
                 }
 

--- a/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerBuyStockCommand.kt
+++ b/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerBuyStockCommand.kt
@@ -13,7 +13,10 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 import net.perfectdreams.loritta.plugin.loribroker.LoriBrokerPlugin
 import net.perfectdreams.loritta.plugin.loribroker.tables.BoughtStocks
-import net.perfectdreams.loritta.utils.*
+import net.perfectdreams.loritta.utils.Emotes
+import net.perfectdreams.loritta.utils.GenericReplies
+import net.perfectdreams.loritta.utils.NumberUtils
+import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.select
 
@@ -92,11 +95,9 @@ class BrokerBuyStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComma
 						this[BoughtStocks.boughtAt] = now
 					}
 
-					lorittaUser.profile.takeSonhosNested(howMuchValue)
-					PaymentUtils.addToTransactionLogNested(
-							howMuchValue,
-							SonhosPaymentReason.STOCKS,
-							givenBy = user.idLong
+					lorittaUser.profile.takeSonhosAndAddToTransactionLogNested(
+						howMuchValue,
+						SonhosPaymentReason.STOCKS
 					)
 				}
 				logger.info { "User ${this.user.idLong} bought $number $tickerId for $howMuchValue" }

--- a/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerCommand.kt
+++ b/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerCommand.kt
@@ -8,7 +8,6 @@ import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractComman
 import net.perfectdreams.loritta.plugin.loribroker.LoriBrokerPlugin
 import net.perfectdreams.loritta.plugin.loribroker.tables.BoughtStocks
 import net.perfectdreams.loritta.utils.Emotes
-import net.perfectdreams.loritta.utils.PaymentUtils
 import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import org.jetbrains.exposed.sql.selectAll
 
@@ -32,17 +31,10 @@ class BrokerCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractCommandBase(p
 					loritta.newSuspendedTransaction {
 						val profile = LorittaLauncher.loritta._getLorittaProfile(user)
 
-						if (profile != null) {
-							profile.addSonhosNested(
-									track
-							)
-
-							PaymentUtils.addToTransactionLogNested(
-									track,
-									SonhosPaymentReason.STOCKS,
-									receivedBy = user
-							)
-						}
+						profile?.addSonhosAndAddToTransactionLogNested(
+							track,
+							SonhosPaymentReason.STOCKS
+						)
 					}
 				}
 

--- a/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerSellStockCommand.kt
+++ b/loritta-plugins/lori-broker/src/main/kotlin/net/perfectdreams/loritta/plugin/loribroker/commands/BrokerSellStockCommand.kt
@@ -13,7 +13,10 @@ import net.perfectdreams.loritta.api.messages.LorittaReply
 import net.perfectdreams.loritta.platform.discord.commands.DiscordAbstractCommandBase
 import net.perfectdreams.loritta.plugin.loribroker.LoriBrokerPlugin
 import net.perfectdreams.loritta.plugin.loribroker.tables.BoughtStocks
-import net.perfectdreams.loritta.utils.*
+import net.perfectdreams.loritta.utils.Emotes
+import net.perfectdreams.loritta.utils.GenericReplies
+import net.perfectdreams.loritta.utils.NumberUtils
+import net.perfectdreams.loritta.utils.SonhosPaymentReason
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.select
@@ -104,11 +107,9 @@ class BrokerSellStockCommand(val plugin: LoriBrokerPlugin) : DiscordAbstractComm
 						BoughtStocks.id inList stocksThatWillBeSold.map { it[BoughtStocks.id] }
 					}
 
-					lorittaUser.profile.addSonhosNested(howMuchWillBePaidToTheUser)
-					PaymentUtils.addToTransactionLogNested(
-							howMuchWillBePaidToTheUser,
-							SonhosPaymentReason.STOCKS,
-							receivedBy = user.idLong
+					lorittaUser.profile.addSonhosAndAddToTransactionLogNested(
+						howMuchWillBePaidToTheUser,
+						SonhosPaymentReason.STOCKS
 					)
 				}
 


### PR DESCRIPTION
This adds a function that merges sonhos add/take with the add sonhos transaction log

A very small refactor that helps a lot when developing stuff that handles sonhos

Keep in mind that this does *not* handle all the stuff that Loritta handles with sonhos (Example: `+pay` adds and removes sonhos from users and adds a single sonhos transactions), this could be added later