### PR TITLE
Solving message limit error.

### DIFF
--- a/platforms/discord/legacy/src/main/java/net/perfectdreams/loritta/utils/GenericReplies.kt
+++ b/platforms/discord/legacy/src/main/java/net/perfectdreams/loritta/utils/GenericReplies.kt
@@ -3,7 +3,7 @@ package net.perfectdreams.loritta.utils
 import com.mrpowergamerbr.loritta.commands.CommandContext
 import com.mrpowergamerbr.loritta.utils.stripCodeMarks
 import net.perfectdreams.loritta.api.messages.LorittaReply
-import net.perfectdreams.loritta.platform.discord.commands.DiscordCommandContext
+import net.perfectdreams.loritta.platform.discord.legacy.commands.DiscordCommandContext
 
 object GenericReplies {
 	suspend fun invalidNumber(context: CommandContext, value: String) {

--- a/platforms/discord/legacy/src/main/java/net/perfectdreams/loritta/utils/GenericReplies.kt
+++ b/platforms/discord/legacy/src/main/java/net/perfectdreams/loritta/utils/GenericReplies.kt
@@ -3,17 +3,17 @@ package net.perfectdreams.loritta.utils
 import com.mrpowergamerbr.loritta.commands.CommandContext
 import com.mrpowergamerbr.loritta.utils.stripCodeMarks
 import net.perfectdreams.loritta.api.messages.LorittaReply
-import net.perfectdreams.loritta.platform.discord.legacy.commands.DiscordCommandContext
+import net.perfectdreams.loritta.platform.discord.commands.DiscordCommandContext
 
 object GenericReplies {
 	suspend fun invalidNumber(context: CommandContext, value: String) {
 		context.reply(
                 LorittaReply(
-                        context.locale["commands.invalidNumber", value.stripCodeMarks()] + " ${Emotes.LORI_CRYING}",
+                        context.locale["commands.invalidNumber", value.stripCodeMarks().take(8)] + " ${Emotes.LORI_CRYING}",
                         Emotes.LORI_HM
                 )
 		)
 	}
 
-	fun invalidNumber(context: DiscordCommandContext, value: String): Nothing = context.fail(context.locale["commands.invalidNumber", value] + " ${Emotes.LORI_CRYING}", Emotes.LORI_HM)
+	fun invalidNumber(context: DiscordCommandContext, value: String): Nothing = context.fail(context.locale["commands.invalidNumber", value.take(8)] + " ${Emotes.LORI_CRYING}", Emotes.LORI_HM)
 }


### PR DESCRIPTION
When you use commands like roll with an invalid number, it returns a message that can turn into an error depending on the size of the user's message. Added a [String#take](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/take.html) to fix this.
![image](https://user-images.githubusercontent.com/35616041/123524437-a23dc280-d6a0-11eb-9e55-7faa124d81e4.png)