### PR TITLE
updated repos and replaced bintray

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ allprojects {
         maven("https://oss.sonatype.org/content/repositories/snapshots/")
 
         // Used by kotlinx.html, can be removed after migrating to the newest kotlinx.html version
-        maven("https://dl.bintray.com/kotlin/kotlinx.html")
+        maven("https://plugins.gradle.org/m2")
         maven("https://repo.perfectdreams.net/")
         maven("https://jitpack.io")
 


### PR DESCRIPTION
updated the repos as Bintray.com has closed down and deleted all files (access denied! error when trying to download kotlinx)