### PR TITLE
 fix error message: morse from command

### DIFF
--- a/commands/src/commonMain/kotlin/net/perfectdreams/loritta/commands/utils/MorseFromExecutor.kt
+++ b/commands/src/commonMain/kotlin/net/perfectdreams/loritta/commands/utils/MorseFromExecutor.kt
@@ -27,7 +27,7 @@ class MorseFromExecutor(val emotes: Emotes): CommandExecutor() {
         if (fromMorse.isBlank())
             context.fail(
                 prefix = emotes.error.asMention,
-                content = context.locale["${MorseCommand.LOCALE_PREFIX}.fail"]
+                content = context.locale["${MorseCommand.LOCALE_PREFIX}.failFrom"]
             ) { isEphemeral = true }
 
         context.sendReply(

--- a/commands/src/commonMain/kotlin/net/perfectdreams/loritta/commands/utils/MorseToExecutor.kt
+++ b/commands/src/commonMain/kotlin/net/perfectdreams/loritta/commands/utils/MorseToExecutor.kt
@@ -27,7 +27,7 @@ class MorseToExecutor(val emotes: Emotes) : CommandExecutor() {
         if (toMorse.isBlank())
             context.fail(
                 prefix = emotes.error.asMention,
-                content = context.locale["${MorseCommand.LOCALE_PREFIX}.fail"]
+                content = context.locale["${MorseCommand.LOCALE_PREFIX}.failTo"]
             ) { isEphemeral = true }
 
         context.sendReply(


### PR DESCRIPTION
## Regarding the issue - https://github.com/LorittaBot/Loritta/issues/2427

My sugestion would be making separate fail messages for each subcommand (morse from, morse to). This would require also changing the loritta locales. Currently there is two fail cases with the same message in the locale files: 
```

failUnknownCharacters:  "Eu não consegui transformar a sua mensagem para código morse... Talvez você tenha colocado apenas caracteres que não existem em código morse!"
...
fail: "Eu não consegui transformar a sua mensagem para código morse... Talvez você tenha colocado apenas caracteres que não existem em código morse!"
```

The updated messages should look like this:
```

failTo: "Eu não consegui transformar a sua mensagem para código morse... Talvez você tenha colocado apenas caracteres que não existem em código morse!"
failFrom: "Eu não consegui transformar a sua mensagem do código morse... Talvez você tenha colocado apenas caracteres inválidos em código morse!"

```