### PR TITLE
Add stats collector microservice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
       if: github.ref == 'refs/heads/cinnamon'
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: ":discord:web-server:jib :discord:gateway:jib :microservices:broker-tickers-updater:jib"
+        arguments: ":discord:web-server:jib :discord:gateway:jib :microservices:broker-tickers-updater:jib :microservices:stats-collector:jib"

--- a/microservices/stats-collector/build.gradle.kts
+++ b/microservices/stats-collector/build.gradle.kts
@@ -36,7 +36,7 @@ jib {
     }
 
     to {
-        image = "ghcr.io/lorittabot/analytics-collector"
+        image = "ghcr.io/lorittabot/stats-collector"
 
         auth {
             username = System.getProperty("DOCKER_USERNAME") ?: System.getenv("DOCKER_USERNAME")

--- a/microservices/stats-collector/build.gradle.kts
+++ b/microservices/stats-collector/build.gradle.kts
@@ -1,0 +1,66 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.serialization")
+    id("com.github.johnrengelman.shadow") version "5.2.0"
+    id("com.google.cloud.tools.jib") version Versions.JIB
+}
+
+dependencies {
+    implementation(project(":pudding:client"))
+    implementation("org.jetbrains.exposed:exposed-core:${Versions.EXPOSED}")
+    implementation("org.jetbrains.exposed:exposed-jdbc:${Versions.EXPOSED}")
+    implementation("org.jetbrains.exposed:exposed-java-time:${Versions.EXPOSED}")
+    implementation("pw.forst", "exposed-upsert", "1.1.0")
+    implementation("io.ktor:ktor-client-cio:1.6.0")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-core:${Versions.KOTLINX_SERIALIZATION}")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.KOTLINX_SERIALIZATION}")
+
+    // Logback GELF, used for Graylog logging
+    implementation("de.siegmar:logback-gelf:3.0.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = Versions.JVM_TARGET
+}
+
+jib {
+    container {
+        ports = listOf("8080")
+    }
+
+    to {
+        image = "ghcr.io/lorittabot/analytics-collector"
+
+        auth {
+            username = System.getProperty("DOCKER_USERNAME") ?: System.getenv("DOCKER_USERNAME")
+            password = System.getProperty("DOCKER_PASSWORD") ?: System.getenv("DOCKER_PASSWORD")
+        }
+    }
+
+    from {
+        image = "openjdk:17-slim-bullseye"
+    }
+}
+
+tasks.withType<ShadowJar> {
+    manifest {
+        attributes["Main-Class"] = "net.perfectdreams.loritta.cinnamon.microservice.statscollector.StatsCollectorLauncher"
+    }
+}
+
+tasks {
+    processResources {
+        from("../../resources/") // Include folders from the resources root folder
+    }
+
+    build {
+        dependsOn(shadowJar)
+    }
+}

--- a/microservices/stats-collector/build.gradle.kts
+++ b/microservices/stats-collector/build.gradle.kts
@@ -31,10 +31,6 @@ tasks.withType<KotlinCompile> {
 }
 
 jib {
-    container {
-        ports = listOf("8080")
-    }
-
     to {
         image = "ghcr.io/lorittabot/stats-collector"
 

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/StatsCollector.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/StatsCollector.kt
@@ -1,0 +1,88 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.endpoints.DatabaseStatsSender
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.endpoints.DiscordBotsStatsSender
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.endpoints.TopggStatsSender
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils.LorittaLegacyStatusResponse
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils.StatsTasks
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils.config.RootConfig
+import net.perfectdreams.loritta.cinnamon.pudding.Pudding
+
+/**
+ * Collects stats from Loritta (Legacy) and sends it to Stats Senders
+ */
+class StatsCollector(val config: RootConfig, val services: Pudding, val http: HttpClient) {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    var shuttingDown = false
+
+    val senders = listOf(
+        TopggStatsSender(http, config.topgg.clientId, config.topgg.token),
+        DiscordBotsStatsSender(http, config.discordBots.clientId, config.discordBots.token),
+        DatabaseStatsSender(services)
+    )
+
+    fun start() {
+        StatsTasks(this).start()
+    }
+
+    fun getLorittaLegacyStatusFromAllClusters() = config.lorittaLegacyClusterUrls.map {
+        async {
+            try {
+                val response = http.get<HttpResponse>("$it/api/v1/loritta/status") {
+                    userAgent("Loritta Cinnamon Analytics Collector")
+                }
+
+                val body = response.readText()
+
+                Json.decodeFromString<LorittaLegacyStatusResponse>(body)
+            } catch (e: Exception) {
+                logger.warn(e) { "Cluster $it is offline!" }
+                throw ClusterOfflineException(it)
+            }
+        }
+    }
+
+    val jobs = mutableListOf<Job>()
+
+    fun launch(block: suspend CoroutineScope.() -> Unit): Job {
+        if (shuttingDown)
+            error("Application is shutting down!")
+
+        val job = GlobalScope.launch(block = block)
+        jobs.add(job)
+        job.invokeOnCompletion {
+            jobs.remove(job)
+        }
+        return job
+    }
+
+    fun <T> async(block: suspend CoroutineScope.() -> T): Deferred<T> {
+        if (shuttingDown)
+            error("Application is shutting down!")
+
+        val job = GlobalScope.async(block = block)
+        jobs.add(job)
+        job.invokeOnCompletion {
+            jobs.remove(job)
+        }
+        return job
+    }
+
+    class ClusterOfflineException(val url: String) : RuntimeException()
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/StatsCollector.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/StatsCollector.kt
@@ -45,7 +45,7 @@ class StatsCollector(val config: RootConfig, val services: Pudding, val http: Ht
         async {
             try {
                 val response = http.get<HttpResponse>("$it/api/v1/loritta/status") {
-                    userAgent("Loritta Cinnamon Analytics Collector")
+                    userAgent("Loritta Cinnamon Stats Collector")
                 }
 
                 val body = response.readText()

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/StatsCollectorLauncher.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/StatsCollectorLauncher.kt
@@ -1,0 +1,58 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector
+
+import io.ktor.client.*
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import mu.KotlinLogging
+import net.perfectdreams.loritta.cinnamon.common.utils.config.ConfigUtils
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils.config.RootConfig
+import net.perfectdreams.loritta.cinnamon.pudding.Pudding
+import kotlin.concurrent.thread
+
+object StatsCollectorLauncher {
+    private val logger = KotlinLogging.logger {}
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val rootConfig = ConfigUtils.loadAndParseConfigOrCopyFromJarAndExit<RootConfig>(StatsCollectorLauncher::class, System.getProperty("analyticscollector.config", "analytics-collector.conf"))
+        logger.info { "Loaded Loritta's configuration file" }
+
+        val http = HttpClient {
+            expectSuccess = false
+        }
+
+        val services = Pudding.createPostgreSQLPudding(
+            rootConfig.pudding.address,
+            rootConfig.pudding.database,
+            rootConfig.pudding.username,
+            rootConfig.pudding.password
+        )
+
+        val loritta = StatsCollector(
+            rootConfig,
+            services,
+            http
+        )
+
+        Runtime.getRuntime().addShutdownHook(
+            thread(false) {
+                loritta.shuttingDown = true
+                loritta.jobs.forEach {
+                    runBlocking {
+                        try {
+                            it.cancelAndJoin()
+                        } catch (e: Exception) {}
+                    }
+                }
+
+                // Shutdown services when stopping the application
+                // This is needed for the Pudding Tasks
+                services.shutdown()
+            }
+        )
+
+        logger.info { "Started Pudding client!" }
+
+        loritta.start()
+    }
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/StatsCollectorLauncher.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/StatsCollectorLauncher.kt
@@ -14,7 +14,7 @@ object StatsCollectorLauncher {
 
     @JvmStatic
     fun main(args: Array<String>) {
-        val rootConfig = ConfigUtils.loadAndParseConfigOrCopyFromJarAndExit<RootConfig>(StatsCollectorLauncher::class, System.getProperty("analyticscollector.config", "analytics-collector.conf"))
+        val rootConfig = ConfigUtils.loadAndParseConfigOrCopyFromJarAndExit<RootConfig>(StatsCollectorLauncher::class, System.getProperty("statscollector.config", "stats-collector.conf"))
         logger.info { "Loaded Loritta's configuration file" }
 
         val http = HttpClient {

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/endpoints/DatabaseStatsSender.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/endpoints/DatabaseStatsSender.kt
@@ -1,0 +1,13 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.endpoints
+
+import kotlinx.datetime.Clock
+import net.perfectdreams.loritta.cinnamon.pudding.Pudding
+
+class DatabaseStatsSender(private val pudding: Pudding) : StatsSender {
+    override suspend fun send(guildCount: Long) {
+        pudding.stats.insertGuildCountStats(
+            guildCount,
+            Clock.System.now()
+        )
+    }
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/endpoints/DiscordBotsStatsSender.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/endpoints/DiscordBotsStatsSender.kt
@@ -1,0 +1,42 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.endpoints
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.content.*
+import io.ktor.http.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+
+class DiscordBotsStatsSender(
+    private val http: HttpClient,
+    private val clientId: Long,
+    private val token: String
+) : StatsSender {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    override suspend fun send(guildCount: Long) {
+        val result = http.post<HttpResponse>("https://discord.bots.gg/api/v1/bots/$clientId/stats") {
+            header("Authorization", token)
+            accept(ContentType.Application.Json)
+            body = TextContent(Json.encodeToString(UpdateBotStatsRequest(guildCount)), ContentType.Application.Json)
+        }
+
+        val response = result.readText()
+        logger.info { "Discord Bots response: $response"}
+
+        if (!result.status.isSuccess())
+            throw RuntimeException("Discord Bots response wasn't a success!")
+    }
+
+    @Serializable
+    data class UpdateBotStatsRequest(
+        @SerialName("guildCount")
+        val serverCount: Long
+    )
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/endpoints/StatsSender.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/endpoints/StatsSender.kt
@@ -1,0 +1,5 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.endpoints
+
+interface StatsSender {
+    suspend fun send(guildCount: Long)
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/endpoints/TopggStatsSender.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/endpoints/TopggStatsSender.kt
@@ -1,0 +1,42 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.endpoints
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.content.*
+import io.ktor.http.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+
+class TopggStatsSender(
+    private val http: HttpClient,
+    private val clientId: Long,
+    private val token: String
+) : StatsSender {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    override suspend fun send(guildCount: Long) {
+        val result = http.post<HttpResponse>("https://top.gg/api/bots/$clientId/stats") {
+            header("Authorization", token)
+            accept(ContentType.Application.Json)
+            body = TextContent(Json.encodeToString(UpdateBotStatsRequest(guildCount)), ContentType.Application.Json)
+        }
+
+        val response = result.readText()
+        logger.info { "top.gg response: $response"}
+
+        if (!result.status.isSuccess())
+            throw RuntimeException("top.gg response wasn't a success!")
+    }
+
+    @Serializable
+    data class UpdateBotStatsRequest(
+        @SerialName("server_count")
+        val serverCount: Long
+    )
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/LorittaLegacyStatusResponse.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/LorittaLegacyStatusResponse.kt
@@ -1,0 +1,54 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LorittaLegacyStatusResponse(
+    val id: Int,
+    val name: String,
+    val versions: Versions,
+    val build: BuildInfo,
+    val memory: Memory,
+    val threadCount: Int,
+    val globalRateLimitHits: Int,
+    val isIgnoringRequests: Boolean,
+    val pendingMessages: Int,
+    val minShard: Int,
+    val maxShard: Int,
+    val uptime: Long,
+    val shards: List<ShardInfo>
+) {
+    @Serializable
+    data class Versions(
+        val kotlin: String,
+        val java: String,
+        val jda: String
+    )
+
+    @Serializable
+    data class BuildInfo(
+        val version: String,
+        val buildNumber: String,
+        val commitHash: String,
+        val gitBranch: String,
+        val compiledAt: String,
+        val environment: String
+    )
+
+    @Serializable
+    data class Memory(
+        val used: Int,
+        val free: Int,
+        val max: Int,
+        val total: Int
+    )
+
+    @Serializable
+    data class ShardInfo(
+        val id: Int,
+        val ping: Int,
+        val status: String,
+        val guildCount: Int,
+        val userCount: Int
+    )
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/LorittaStatsCollector.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/LorittaStatsCollector.kt
@@ -10,7 +10,7 @@ class LorittaStatsCollector(val m: StatsCollector) : RunnableCoroutineWrapper() 
 
     override suspend fun runCoroutine() {
         try {
-            logger.info { "Collecting analytics data from Loritta Legacy..." }
+            logger.info { "Collecting stats data from Loritta Legacy..." }
             val statuses = m.getLorittaLegacyStatusFromAllClusters()
 
             var guildCount = 0L
@@ -21,13 +21,13 @@ class LorittaStatsCollector(val m: StatsCollector) : RunnableCoroutineWrapper() 
 
                     val areAllShardsAreReady = status.shards.any { it.status == "CONNECTED" }
                     if (!areAllShardsAreReady) {
-                        logger.warn { "Shards in ${status.id} (${status.name}) are not ready! Skipping analytics collection task..." }
+                        logger.warn { "Shards in ${status.id} (${status.name}) are not ready! Skipping stats collection task..." }
                         return
                     }
 
                     guildCount += status.shards.sumOf { it.guildCount }
                 } catch (e: StatsCollector.ClusterOfflineException) {
-                    logger.warn(e) { "Cluster ${e.url} is offline! Skipping analytics collection task..." }
+                    logger.warn(e) { "Cluster ${e.url} is offline! Skipping stats collection task..." }
                     return
                 }
             }
@@ -39,13 +39,13 @@ class LorittaStatsCollector(val m: StatsCollector) : RunnableCoroutineWrapper() 
             jobs.forEach {
                 try {
                     it.second.join()
-                    logger.info { "Successfully sent Loritta Legacy's analytics data to ${it.first}!" }
+                    logger.info { "Successfully sent Loritta Legacy's stats data to ${it.first}!" }
                 } catch (e: Exception) {
-                    logger.warn(e) { "Something went wrong while trying to send Loritta Legacy's analytics data to ${it.first}!" }
+                    logger.warn(e) { "Something went wrong while trying to send Loritta Legacy's stats data to ${it.first}!" }
                 }
             }
         } catch (e: Exception) {
-            logger.warn { "Something went wrong while collecting and sending analytics data!" }
+            logger.warn { "Something went wrong while collecting and sending stats data!" }
         }
     }
 }

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/LorittaStatsCollector.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/LorittaStatsCollector.kt
@@ -1,0 +1,51 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils
+
+import mu.KotlinLogging
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.StatsCollector
+
+class LorittaStatsCollector(val m: StatsCollector) : RunnableCoroutineWrapper() {
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    override suspend fun runCoroutine() {
+        try {
+            logger.info { "Collecting analytics data from Loritta Legacy..." }
+            val statuses = m.getLorittaLegacyStatusFromAllClusters()
+
+            var guildCount = 0L
+
+            for (statusJob in statuses) {
+                try {
+                    val status = statusJob.await()
+
+                    val areAllShardsAreReady = status.shards.any { it.status == "CONNECTED" }
+                    if (!areAllShardsAreReady) {
+                        logger.warn { "Shards in ${status.id} (${status.name}) are not ready! Skipping analytics collection task..." }
+                        return
+                    }
+
+                    guildCount += status.shards.sumOf { it.guildCount }
+                } catch (e: StatsCollector.ClusterOfflineException) {
+                    logger.warn(e) { "Cluster ${e.url} is offline! Skipping analytics collection task..." }
+                    return
+                }
+            }
+
+            val jobs = m.senders.map {
+                it to m.launch { it.send(guildCount) }
+            }
+
+            jobs.forEach {
+                try {
+                    it.second.join()
+                    logger.info { "Successfully sent Loritta Legacy's analytics data to ${it.first}!" }
+                } catch (e: Exception) {
+                    logger.warn(e) { "Something went wrong while trying to send Loritta Legacy's analytics data to ${it.first}!" }
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn { "Something went wrong while collecting and sending analytics data!" }
+        }
+    }
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/RunnableCoroutineWrapper.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/RunnableCoroutineWrapper.kt
@@ -1,0 +1,11 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils
+
+import kotlinx.coroutines.runBlocking
+
+abstract class RunnableCoroutineWrapper : Runnable {
+    override fun run() = runBlocking {
+        runCoroutine()
+    }
+
+    abstract suspend fun runCoroutine()
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/StatsTasks.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/StatsTasks.kt
@@ -1,0 +1,22 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils
+
+import net.perfectdreams.loritta.cinnamon.microservices.statscollector.StatsCollector
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class StatsTasks(private val m: StatsCollector) {
+    private val executorService = Executors.newScheduledThreadPool(1)
+
+    fun start() {
+        executorService.scheduleWithFixedDelay(
+            LorittaStatsCollector(m),
+            0L,
+            1L,
+            TimeUnit.MINUTES
+        )
+    }
+
+    fun shutdown() {
+        executorService.shutdown()
+    }
+}

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/config/DiscordBotsConfig.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/config/DiscordBotsConfig.kt
@@ -1,0 +1,9 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils.config
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DiscordBotsConfig(
+    val clientId: Long,
+    val token: String
+)

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/config/PuddingConfig.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/config/PuddingConfig.kt
@@ -1,0 +1,11 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils.config
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PuddingConfig(
+    val database: String,
+    val address: String,
+    val username: String,
+    val password: String
+)

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/config/RootConfig.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/config/RootConfig.kt
@@ -1,0 +1,11 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils.config
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RootConfig(
+    val lorittaLegacyClusterUrls: List<String>,
+    val topgg: TopggConfig,
+    val discordBots: DiscordBotsConfig,
+    val pudding: PuddingConfig
+)

--- a/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/config/TopggConfig.kt
+++ b/microservices/stats-collector/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/statscollector/utils/config/TopggConfig.kt
@@ -1,0 +1,9 @@
+package net.perfectdreams.loritta.cinnamon.microservices.statscollector.utils.config
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TopggConfig(
+    val clientId: Long,
+    val token: String
+)

--- a/microservices/stats-collector/src/main/resources/analytics-collector.conf
+++ b/microservices/stats-collector/src/main/resources/analytics-collector.conf
@@ -1,0 +1,28 @@
+lorittaLegacyClusterUrls = [
+    "https://loritta.website"
+]
+
+topgg {
+    clientId = the bot id
+    token = "top.gg token"
+}
+
+discordBots {
+    clientId = the bot id
+    token = "discord bots token"
+}
+
+pudding {
+    # Information about the PostgreSQL server that will be used to store data
+    # The database name in the PostgreSQL server
+    database = "loritta"
+
+    # The address of the PostgreSQL server
+    address = "127.0.0.1:5432"
+
+    # The username of the PostgreSQL server
+    username = "the database username"
+
+    # The password of the PostgreSQL server
+    password = "the database password"
+}

--- a/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/Pudding.kt
+++ b/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/Pudding.kt
@@ -21,6 +21,7 @@ import net.perfectdreams.loritta.cinnamon.pudding.services.ProfileDesignsService
 import net.perfectdreams.loritta.cinnamon.pudding.services.ServerConfigsService
 import net.perfectdreams.loritta.cinnamon.pudding.services.ShipEffectsService
 import net.perfectdreams.loritta.cinnamon.pudding.services.SonhosService
+import net.perfectdreams.loritta.cinnamon.pudding.services.StatsService
 import net.perfectdreams.loritta.cinnamon.pudding.services.UsersService
 import net.perfectdreams.loritta.cinnamon.pudding.tables.BackgroundPayments
 import net.perfectdreams.loritta.cinnamon.pudding.tables.BackgroundVariations
@@ -35,6 +36,7 @@ import net.perfectdreams.loritta.cinnamon.pudding.tables.CoinFlipBetGlobalSonhos
 import net.perfectdreams.loritta.cinnamon.pudding.tables.Dailies
 import net.perfectdreams.loritta.cinnamon.pudding.tables.ExecutedApplicationCommandsLog
 import net.perfectdreams.loritta.cinnamon.pudding.tables.ExecutedComponentsLog
+import net.perfectdreams.loritta.cinnamon.pudding.tables.GuildCountStats
 import net.perfectdreams.loritta.cinnamon.pudding.tables.InteractionsData
 import net.perfectdreams.loritta.cinnamon.pudding.tables.Marriages
 import net.perfectdreams.loritta.cinnamon.pudding.tables.Payments
@@ -164,6 +166,7 @@ class Pudding(private val database: Database) {
     val bovespaBroker = BovespaBrokerService(this)
     val bets = BetsService(this)
     val payments = PaymentsService(this)
+    val stats = StatsService(this)
     val puddingTasks = PuddingTasks(this)
     val random = SecureRandom()
 
@@ -213,7 +216,8 @@ class Pudding(private val database: Database) {
             CoinFlipBetGlobalSonhosTransactionsLog,
             SparklyPowerLSXSonhosTransactionsLog,
             Dailies,
-            Payments
+            Payments,
+            GuildCountStats
         )
 
         if (schemas.isNotEmpty())

--- a/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/services/StatsService.kt
+++ b/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/services/StatsService.kt
@@ -1,0 +1,21 @@
+package net.perfectdreams.loritta.cinnamon.pudding.services
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
+import net.perfectdreams.loritta.cinnamon.pudding.Pudding
+import net.perfectdreams.loritta.cinnamon.pudding.tables.GuildCountStats
+import org.jetbrains.exposed.sql.insert
+
+class StatsService(private val pudding: Pudding) : Service(pudding) {
+    suspend fun insertGuildCountStats(
+        guildCount: Long,
+        time: Instant
+    ) {
+        pudding.transaction {
+            GuildCountStats.insert {
+                it[GuildCountStats.timestamp] = time.toJavaInstant()
+                it[GuildCountStats.guildCount] = guildCount
+            }
+        }
+    }
+}

--- a/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/tables/GuildCountStats.kt
+++ b/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/tables/GuildCountStats.kt
@@ -1,0 +1,9 @@
+package net.perfectdreams.loritta.cinnamon.pudding.tables
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.javatime.timestamp
+
+object GuildCountStats : LongIdTable() {
+    val timestamp = timestamp("timestamp").index()
+    val guildCount = long("guild_count")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,3 +26,4 @@ include(":discord:gateway")
 
 // ===[ MICROSERVICES ]===
 include("microservices:broker-tickers-updater")
+include("microservices:stats-collector")


### PR DESCRIPTION
Collects guild count data from Loritta (Legacy) and sends it to top.gg, Discord Bots and to Loritta's own database, useful for when a `/botinfo` is implemented (Because Loritta shows the current guild count there)

Fixes #2429

