### PR TITLE
Add button to switch between the user's global avatar and guild avatar

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -8,7 +8,7 @@ object Versions {
     const val EXPOSED = "0.36.2"
     const val PROMETHEUS = "0.12.0"
     const val KTOR = "1.6.7"
-    const val DISCORD_INTERAKTIONS = "0.0.12-20220319.162224-21"
+    const val DISCORD_INTERAKTIONS = "0.0.12-20220322.205903-23"
     const val KORD = "0.8.x-20220315.083129-149" // Should match Discord InteraKTions
     const val I18N_HELPER = "0.0.4-SNAPSHOT"
     const val KOTLINX_DATE_TIME = "0.3.1"

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/CommandManager.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/CommandManager.kt
@@ -43,6 +43,8 @@ import net.perfectdreams.loritta.cinnamon.platform.commands.discord.RoleInfoExec
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.ServerBannerExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.ServerIconExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.ServerSplashExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.SwitchToGlobalAvatarExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.SwitchToGuildProfileAvatarExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.UserAvatarExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.UserBannerExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.WebhookEditJsonExecutor
@@ -225,6 +227,16 @@ class CommandManager(
             UserCommand,
             UserAvatarExecutor(Snowflake(discordConfig.applicationId)),
             UserBannerExecutor(rest)
+        )
+
+        commandManager.register(
+            SwitchToGuildProfileAvatarExecutor,
+            SwitchToGuildProfileAvatarExecutor(loritta, Snowflake(discordConfig.applicationId))
+        )
+
+        commandManager.register(
+            SwitchToGlobalAvatarExecutor,
+            SwitchToGlobalAvatarExecutor(loritta, Snowflake(discordConfig.applicationId))
         )
 
         commandManager.register(

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/ComponentExecutorIds.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/ComponentExecutorIds.kt
@@ -18,6 +18,8 @@ object ComponentExecutorIds {
     val CHANGE_TRANSACTION_PAGE_BUTTON_EXECUTOR = register("0007")
     val CHANGE_TRANSACTION_FILTER_SELECT_MENU_EXECUTOR = register("0008")
     val START_MATCHMAKING_BUTTON_EXECUTOR = register("0009")
+    val SWITCH_TO_GUILD_PROFILE_AVATAR_EXECUTOR = register("0010")
+    val SWITCH_TO_GLOBAL_AVATAR_EXECUTOR = register("0011")
 
     /**
      * Verifies if the [id] matches our constraints

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/SwitchToGlobalAvatarExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/SwitchToGlobalAvatarExecutor.kt
@@ -1,0 +1,41 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord
+
+import dev.kord.common.entity.Snowflake
+import net.perfectdreams.discordinteraktions.common.entities.User
+import net.perfectdreams.loritta.cinnamon.platform.LorittaCinnamon
+import net.perfectdreams.loritta.cinnamon.platform.commands.ComponentExecutorIds
+import net.perfectdreams.loritta.cinnamon.platform.components.ButtonClickExecutorDeclaration
+import net.perfectdreams.loritta.cinnamon.platform.components.ButtonClickWithDataExecutor
+import net.perfectdreams.loritta.cinnamon.platform.components.ComponentContext
+
+class SwitchToGlobalAvatarExecutor(val loritta: LorittaCinnamon, val lorittaId: Snowflake) : ButtonClickWithDataExecutor {
+    companion object : ButtonClickExecutorDeclaration(SwitchToGlobalAvatarExecutor::class, ComponentExecutorIds.SWITCH_TO_GLOBAL_AVATAR_EXECUTOR)
+
+    override suspend fun onClick(user: User, context: ComponentContext, data: String) {
+        val decodedInteractionData = context.decodeViaComponentDataUtilsAndRequireUserToMatch<UserDataUtils.SwitchAvatarInteractionIdData>(data)
+        val data = UserDataUtils.getInteractionDataOrRetrieveViaRestIfItDoesNotExist(
+            loritta,
+            decodedInteractionData,
+            false
+        )
+
+        val newData = UserDataUtils.ViewingGlobalUserAvatarData(
+            data.userName,
+            data.discriminator,
+            data.userAvatarId,
+            data.memberAvatarId
+        )
+
+        val message = UserDataUtils.createAvatarPreviewMessage(
+            loritta,
+            context.i18nContext,
+            lorittaId,
+            decodedInteractionData,
+            newData
+        )
+
+        context.updateMessage {
+            message()
+        }
+    }
+}

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/SwitchToGuildProfileAvatarExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/SwitchToGuildProfileAvatarExecutor.kt
@@ -1,0 +1,41 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord
+
+import dev.kord.common.entity.Snowflake
+import net.perfectdreams.discordinteraktions.common.entities.User
+import net.perfectdreams.loritta.cinnamon.platform.LorittaCinnamon
+import net.perfectdreams.loritta.cinnamon.platform.commands.ComponentExecutorIds
+import net.perfectdreams.loritta.cinnamon.platform.components.ButtonClickExecutorDeclaration
+import net.perfectdreams.loritta.cinnamon.platform.components.ButtonClickWithDataExecutor
+import net.perfectdreams.loritta.cinnamon.platform.components.ComponentContext
+
+class SwitchToGuildProfileAvatarExecutor(val loritta: LorittaCinnamon, val lorittaId: Snowflake) : ButtonClickWithDataExecutor {
+    companion object : ButtonClickExecutorDeclaration(SwitchToGuildProfileAvatarExecutor::class, ComponentExecutorIds.SWITCH_TO_GUILD_PROFILE_AVATAR_EXECUTOR)
+
+    override suspend fun onClick(user: User, context: ComponentContext, data: String) {
+        val decodedInteractionData = context.decodeViaComponentDataUtilsAndRequireUserToMatch<UserDataUtils.SwitchAvatarInteractionIdData>(data)
+        val data = UserDataUtils.getInteractionDataOrRetrieveViaRestIfItDoesNotExist(
+            loritta,
+            decodedInteractionData,
+            true
+        )
+
+        val newData = UserDataUtils.ViewingGuildProfileUserAvatarData(
+            data.userName,
+            data.discriminator,
+            data.userAvatarId,
+            data.memberAvatarId!! // at this point it should not be null
+        )
+
+        val message = UserDataUtils.createAvatarPreviewMessage(
+            loritta,
+            context.i18nContext,
+            lorittaId,
+            decodedInteractionData,
+            newData
+        )
+
+        context.updateMessage {
+            message()
+        }
+    }
+}

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/UserDataUtils.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/UserDataUtils.kt
@@ -1,0 +1,263 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord
+
+import dev.kord.common.Color
+import dev.kord.common.entity.ButtonStyle
+import dev.kord.common.entity.DiscordGuildMember
+import dev.kord.common.entity.Snowflake
+import dev.kord.rest.Image
+import kotlinx.datetime.Clock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import net.perfectdreams.discordinteraktions.common.builder.message.MessageBuilder
+import net.perfectdreams.discordinteraktions.common.builder.message.actionRow
+import net.perfectdreams.discordinteraktions.common.builder.message.embed
+import net.perfectdreams.discordinteraktions.common.entities.Icon
+import net.perfectdreams.discordinteraktions.common.utils.footer
+import net.perfectdreams.i18nhelper.core.I18nContext
+import net.perfectdreams.loritta.cinnamon.i18n.I18nKeysData
+import net.perfectdreams.loritta.cinnamon.platform.LorittaCinnamon
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations.UserCommand
+import net.perfectdreams.loritta.cinnamon.platform.components.data.SingleUserComponentData
+import net.perfectdreams.loritta.cinnamon.platform.components.interactiveButton
+import net.perfectdreams.loritta.cinnamon.platform.utils.ComponentDataUtils
+import net.perfectdreams.loritta.cinnamon.platform.utils.NotableUserIds
+import kotlin.time.Duration.Companion.minutes
+
+object UserDataUtils {
+    suspend fun getInteractionDataOrRetrieveViaRestIfItDoesNotExist(
+        loritta: LorittaCinnamon,
+        decodedInteractionData: SwitchAvatarInteractionIdData,
+        isLookingGuildProfileAvatar: Boolean
+    ): ViewingUserAvatarData {
+        val storedInteractionData = loritta.services.interactionsData.getInteractionData(decodedInteractionData.interactionDataId)
+
+        if (storedInteractionData == null) {
+            // ID is not present, try pulling the user data via REST
+            val guildId = decodedInteractionData.guildId
+
+            // TODO: We need to catch errors here! What if the member has left the server?
+            var member: DiscordGuildMember? = null
+            val user = loritta.rest.user.getUser(decodedInteractionData.viewingAvatarOfId)
+
+            if (guildId != null)
+                member = loritta.rest.guild.getGuildMember(guildId, decodedInteractionData.viewingAvatarOfId)
+
+            val memberAvatarHash = member?.avatar?.value
+            // If we tried looking at the user's guild profile avatar, but it doesn't exist, fallback to global user avatar data
+            return if (isLookingGuildProfileAvatar && memberAvatarHash != null) {
+                ViewingGuildProfileUserAvatarData(
+                    user.username,
+                    user.discriminator.toInt(),
+                    user.avatar,
+                    memberAvatarHash
+                )
+            } else {
+                ViewingGlobalUserAvatarData(
+                    user.username,
+                    user.discriminator.toInt(),
+                    user.avatar,
+                    memberAvatarHash
+                )
+            }
+        }
+
+        return Json.decodeFromJsonElement(storedInteractionData)
+    }
+
+    /**
+     * Creates an avatar preview embed from the data in [data]
+     */
+    fun createAvatarPreviewMessage(
+        loritta: LorittaCinnamon,
+        i18nContext: I18nContext,
+        lorittaId: Snowflake,
+        interactionData: SwitchAvatarInteractionIdData,
+        data: ViewingUserAvatarData
+    ): suspend MessageBuilder.() -> (Unit) {
+        val now = Clock.System.now()
+
+        // Unwrap our data so it is easier to access
+        val userId = interactionData.viewingAvatarOfId
+        val userName = data.userName
+        val userDiscriminator = data.discriminator
+
+        val userAvatar: Icon?
+        val avatarHash: String?
+
+        // Convert our stored data into Icons, and store them in the "avatarHash" variable so we can check later if it is a GIF or not
+        when (data) {
+            is ViewingGuildProfileUserAvatarData -> {
+                avatarHash = data.memberAvatarId
+                userAvatar = Icon.MemberAvatar(
+                    interactionData.guildId!!,
+                    userId,
+                    data.memberAvatarId
+                )
+            }
+            is ViewingGlobalUserAvatarData -> {
+                avatarHash = data.userAvatarId
+                userAvatar = if (avatarHash != null) {
+                    Icon.UserAvatar(
+                        interactionData.viewingAvatarOfId,
+                        avatarHash
+                    )
+                } else Icon.DefaultUserAvatar(userDiscriminator)
+            }
+        }
+
+        // Create the avatar message
+        return {
+            embed {
+                title = "\uD83D\uDDBC $userName"
+
+                // Specific User Avatar Easter Egg Texts
+                val easterEggFooterTextKey = when {
+                    // Easter Egg: Looking up yourself
+                    interactionData.userId == interactionData.viewingAvatarOfId -> UserCommand.I18N_PREFIX.Avatar.YourselfEasterEgg
+
+                    // Easter Egg: Loritta/Application ID
+                    // TODO: Show who made the fan art during the Fan Art Extravaganza
+                    userId == lorittaId -> UserCommand.I18N_PREFIX.Avatar.LorittaEasterEgg
+
+                    // Easter Egg: Pantufa
+                    userId == NotableUserIds.PANTUFA -> UserCommand.I18N_PREFIX.Avatar.PantufaEasterEgg
+
+                    // Easter Egg: Gabriela
+                    userId == NotableUserIds.GABRIELA -> UserCommand.I18N_PREFIX.Avatar.GabrielaEasterEgg
+
+                    // Easter Egg: Carl-bot
+                    userId == NotableUserIds.CARLBOT -> UserCommand.I18N_PREFIX.Avatar.CarlbotEasterEgg
+
+                    // Easter Egg: Dank Memer
+                    userId == NotableUserIds.DANK_MEMER -> UserCommand.I18N_PREFIX.Avatar.DankMemerEasterEgg
+
+                    // Easter Egg: Mantaro
+                    userId == NotableUserIds.MANTARO -> UserCommand.I18N_PREFIX.Avatar.MantaroEasterEgg
+
+                    // Easter Egg: Erisly
+                    userId == NotableUserIds.ERISLY -> UserCommand.I18N_PREFIX.Avatar.ErislyEasterEgg
+
+                    // Easter Egg: Kuraminha
+                    userId == NotableUserIds.KURAMINHA -> UserCommand.I18N_PREFIX.Avatar.KuraminhaEasterEgg
+
+                    // Nothing else, just use null
+                    else -> null
+                }
+
+                // If the text is present, set it as the footer!
+                if (easterEggFooterTextKey != null)
+                    footer(i18nContext.get(easterEggFooterTextKey))
+
+                color = Color(114, 137, 218) // TODO: Move this to an object
+
+                val imageUrl = userAvatar.cdnUrl.toUrl {
+                    // Images that start with "a_" means that are an animated image
+                    this.format = if (avatarHash?.startsWith("a_") == true) Image.Format.GIF else Image.Format.PNG
+                    this.size = Image.Size.Size2048
+                }
+                image = imageUrl
+
+                actionRow {
+                    // "Open Avatar in Browser" button
+                    linkButton(
+                        url = imageUrl
+                    ) {
+                        label = i18nContext.get(I18nKeysData.Commands.Command.User.Avatar.OpenAvatarInBrowser)
+                    }
+
+                    // Additional avatar switch buttons, if needed
+                    val memberAvatarId = data.memberAvatarId
+                    if (data is ViewingGuildProfileUserAvatarData) {
+                        // If the user is currently viewing the user's guild profile avatar, add a button to switch to the original avatar
+                        val id = loritta.services.interactionsData.insertInteractionData(
+                            Json.encodeToJsonElement<ViewingUserAvatarData>(
+                                ViewingGlobalUserAvatarData(
+                                    data.userName,
+                                    data.discriminator,
+                                    data.userAvatarId,
+                                    data.memberAvatarId
+                                )
+                            ).jsonObject,
+                            now,
+                            now + 15.minutes // Expires after 15m
+                        )
+
+                        interactiveButton(
+                            ButtonStyle.Primary,
+                            SwitchToGlobalAvatarExecutor,
+                            ComponentDataUtils.encode(
+                                interactionData
+                                    .copy(interactionDataId = id)
+                            )
+                        ) {
+                            label = i18nContext.get(UserCommand.I18N_PREFIX.Avatar.ViewUserGlobalAvatar)
+                        }
+                    } else if (memberAvatarId != null) {
+                        // If the user is currently viewing the user's avatar, and the user has a guild profile avatar, add a button to switch to the guild profile avatar
+                        val id = loritta.services.interactionsData.insertInteractionData(
+                            Json.encodeToJsonElement<ViewingUserAvatarData>(
+                                ViewingGuildProfileUserAvatarData(
+                                    data.userName,
+                                    data.discriminator,
+                                    data.userAvatarId,
+                                    memberAvatarId
+                                )
+                            ).jsonObject,
+                            now,
+                            now + 15.minutes // Expires after 15m
+                        )
+
+                        interactiveButton(
+                            ButtonStyle.Primary,
+                            SwitchToGuildProfileAvatarExecutor,
+                            ComponentDataUtils.encode(
+                                interactionData
+                                    .copy(interactionDataId = id)
+                            )
+                        ) {
+                            label = i18nContext.get(UserCommand.I18N_PREFIX.Avatar.ViewUserGuildProfileAvatar)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * We don't store the data in [ViewingUserAvatarData] here because it won't fit in the Custom ID! (avatar IDs are one hecc of a chonky boi)
+     */
+    @Serializable
+    data class SwitchAvatarInteractionIdData(
+        override val userId: Snowflake,
+        val viewingAvatarOfId: Snowflake,
+        val guildId: Snowflake?,
+        val interactionDataId: Long
+    ) : SingleUserComponentData
+
+    @Serializable
+    sealed class ViewingUserAvatarData {
+        abstract val userName: String
+        abstract val discriminator: Int
+        abstract val userAvatarId: String?
+        abstract val memberAvatarId: String?
+    }
+
+    @Serializable
+    data class ViewingGlobalUserAvatarData(
+        override val userName: String,
+        override val discriminator: Int,
+        override val userAvatarId: String?,
+        override val memberAvatarId: String?
+    ) : ViewingUserAvatarData()
+
+    @Serializable
+    data class ViewingGuildProfileUserAvatarData(
+        override val userName: String,
+        override val discriminator: Int,
+        override val userAvatarId: String?,
+        override val memberAvatarId: String
+    ) : ViewingUserAvatarData()
+}

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/fun/HungerGamesExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/fun/HungerGamesExecutor.kt
@@ -1,5 +1,6 @@
 package net.perfectdreams.loritta.cinnamon.platform.commands.`fun`
 
+import dev.kord.rest.Image
 import dev.kord.rest.service.RestClient
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
@@ -59,7 +60,10 @@ class HungerGamesExecutor(val rest: RestClient) : SlashCommandExecutor() {
             "$hungerGamesUrl/personalize-24.php",
             formData {
                 append("seasonname", guild.name)
-                append("logourl", if (guild.icon != null) urlIcon else context.user.avatar.url)
+                append("logourl", if (guild.icon != null) urlIcon else context.user.avatar.cdnUrl.toUrl {
+                    this.size = Image.Size.Size128
+                    this.format = Image.Format.PNG
+                })
                 append("existinglogo", "00")
 
                 for ((index, user) in users.withIndex()) {
@@ -67,7 +71,10 @@ class HungerGamesExecutor(val rest: RestClient) : SlashCommandExecutor() {
 
                     append("cusTribute$numberWithPadding", user.name)
 
-                    append("cusTribute${numberWithPadding}img", user.avatar.url)
+                    append("cusTribute${numberWithPadding}img", user.avatar.cdnUrl.toUrl {
+                        this.size = Image.Size.Size128
+                        this.format = Image.Format.PNG
+                    })
 
                     // TODO: Character Gender
                     // 0 = female

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/fun/ShipExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/fun/ShipExecutor.kt
@@ -1,6 +1,7 @@
 package net.perfectdreams.loritta.cinnamon.platform.commands.`fun`
 
 import dev.kord.common.entity.Snowflake
+import dev.kord.rest.Image
 import kotlinx.datetime.Clock
 import net.perfectdreams.discordinteraktions.common.entities.User
 import net.perfectdreams.gabrielaimageserver.client.GabrielaImageServerClient
@@ -74,7 +75,10 @@ class ShipExecutor(
 
                 user1Id = result1.user.id.value.toLong()
                 user1Name = result1.user.name
-                user1AvatarUrl = result1.user.avatar.url
+                user1AvatarUrl = result1.user.avatar.cdnUrl.toUrl {
+                    this.size = Image.Size.Size128
+                    this.format = Image.Format.PNG
+                }
             }
             is StringWithImageResult -> {
                 user1Id = result1.string.hashCode().toLong()
@@ -95,7 +99,10 @@ class ShipExecutor(
 
                 user2Id = result2.user.id.value.toLong()
                 user2Name = result2.user.name
-                user2AvatarUrl = result2.user.avatar.url
+                user2AvatarUrl = result2.user.avatar.cdnUrl.toUrl {
+                    this.size = Image.Size.Size128
+                    this.format = Image.Format.PNG
+                }
             }
             is StringWithImageResult -> {
                 user2Id = result2.string.hashCode().toLong()

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/images/SadRealityExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/images/SadRealityExecutor.kt
@@ -1,9 +1,10 @@
 package net.perfectdreams.loritta.cinnamon.platform.commands.images
 
 import dev.kord.common.entity.Snowflake
+import dev.kord.rest.Image
 import dev.kord.rest.request.KtorRequestException
 import dev.kord.rest.service.RestClient
-import net.perfectdreams.discordinteraktions.common.entities.UserAvatar
+import net.perfectdreams.discordinteraktions.common.entities.Icon
 import net.perfectdreams.gabrielaimageserver.client.GabrielaImageServerClient
 import net.perfectdreams.gabrielaimageserver.data.SadRealityRequest
 import net.perfectdreams.gabrielaimageserver.data.URLImageData
@@ -60,12 +61,66 @@ class SadRealityExecutor(
         val user6FromArguments = args[options.user6]
 
         val listOfUsers = mutableListOf(
-            user1FromArguments?.let { SadRealityUser(it.id, "${it.name}#${it.discriminator}", it.avatar) },
-            user2FromArguments?.let { SadRealityUser(it.id, "${it.name}#${it.discriminator}", it.avatar) },
-            user3FromArguments?.let { SadRealityUser(it.id, "${it.name}#${it.discriminator}", it.avatar) },
-            user4FromArguments?.let { SadRealityUser(it.id, "${it.name}#${it.discriminator}", it.avatar) },
-            user5FromArguments?.let { SadRealityUser(it.id, "${it.name}#${it.discriminator}", it.avatar) },
-            user6FromArguments?.let { SadRealityUser(it.id, "${it.name}#${it.discriminator}", it.avatar) }
+            user1FromArguments?.let {
+                SadRealityUser(
+                    it.id,
+                    "${it.name}#${it.discriminator}",
+                    it.avatar.cdnUrl.toUrl {
+                        this.size = Image.Size.Size128
+                        this.format = Image.Format.PNG
+                    }
+                )
+            },
+            user2FromArguments?.let {
+                SadRealityUser(
+                    it.id,
+                    "${it.name}#${it.discriminator}",
+                    it.avatar.cdnUrl.toUrl {
+                        this.size = Image.Size.Size128
+                        this.format = Image.Format.PNG
+                    }
+                )
+            },
+            user3FromArguments?.let {
+                SadRealityUser(
+                    it.id,
+                    "${it.name}#${it.discriminator}",
+                    it.avatar.cdnUrl.toUrl {
+                        this.size = Image.Size.Size128
+                        this.format = Image.Format.PNG
+                    }
+                )
+            },
+            user4FromArguments?.let {
+                SadRealityUser(
+                    it.id,
+                    "${it.name}#${it.discriminator}",
+                    it.avatar.cdnUrl.toUrl {
+                        this.size = Image.Size.Size128
+                        this.format = Image.Format.PNG
+                    }
+                )
+            },
+            user5FromArguments?.let {
+                SadRealityUser(
+                    it.id,
+                    "${it.name}#${it.discriminator}",
+                    it.avatar.cdnUrl.toUrl {
+                        this.size = Image.Size.Size128
+                        this.format = Image.Format.PNG
+                    }
+                )
+            },
+            user6FromArguments?.let {
+                SadRealityUser(
+                    it.id,
+                    "${it.name}#${it.discriminator}",
+                    it.avatar.cdnUrl.toUrl {
+                        this.size = Image.Size.Size128
+                        this.format = Image.Format.PNG
+                    }
+                )
+            }
         )
 
         var noPermissionToQuery = false
@@ -92,7 +147,21 @@ class SadRealityExecutor(
                 while (listOfUsers.filterNotNull().size != 6 && uniqueNonBotUsers.isNotEmpty()) {
                     val indexOfFirstNullEntry = listOfUsers.indexOf(null)
                     listOfUsers[indexOfFirstNullEntry] = uniqueNonBotUsers.poll()?.let {
-                        SadRealityUser(it.id, "${it.username}#${it.discriminator}", UserAvatar(it.id.value, it.discriminator.toInt(), it.avatar))
+                        SadRealityUser(
+                            it.id,
+                            "${it.username}#${it.discriminator}",
+                            (it.avatar?.let { avatarHash ->
+                                Icon.UserAvatar(
+                                    it.id,
+                                    avatarHash
+                                )
+                            } ?: Icon.DefaultUserAvatar(it.discriminator.toInt()))
+                                .cdnUrl
+                                .toUrl {
+                                    this.size = Image.Size.Size128
+                                    this.format = Image.Format.PNG
+                                }
+                        )
                     }
                 }
 
@@ -100,7 +169,21 @@ class SadRealityExecutor(
                 while (listOfUsers.filterNotNull().size != 6 && uniqueBotUsers.isNotEmpty()) {
                     val indexOfFirstNullEntry = listOfUsers.indexOf(null)
                     listOfUsers[indexOfFirstNullEntry] = uniqueBotUsers.poll()?.let {
-                        SadRealityUser(it.id, "${it.username}#${it.discriminator}", UserAvatar(it.id.value, it.discriminator.toInt(), it.avatar))
+                        SadRealityUser(
+                            it.id,
+                            "${it.username}#${it.discriminator}",
+                            (it.avatar?.let { avatarHash ->
+                                Icon.UserAvatar(
+                                    it.id,
+                                    avatarHash
+                                )
+                            } ?: Icon.DefaultUserAvatar(it.discriminator.toInt()))
+                                .cdnUrl
+                                .toUrl {
+                                    this.size = Image.Size.Size128
+                                    this.format = Image.Format.PNG
+                                }
+                        )
                     }
                 }
             } catch (e: KtorRequestException) {
@@ -163,7 +246,7 @@ class SadRealityExecutor(
                         }
                     },
                     user1.tag,
-                    URLImageData(user1.avatar.url)
+                    URLImageData(user1.avatarUrl)
                 ),
                 SadRealityRequest.SadRealityUser(
                     when (theFatherGender) {
@@ -179,7 +262,7 @@ class SadRealityExecutor(
                         }
                     },
                     user2.tag,
-                    URLImageData(user2.avatar.url),
+                    URLImageData(user2.avatarUrl),
                 ),
                 SadRealityRequest.SadRealityUser(
                     when (theBrotherGender) {
@@ -195,7 +278,7 @@ class SadRealityExecutor(
                         }
                     },
                     user3.tag,
-                    URLImageData(user3.avatar.url),
+                    URLImageData(user3.avatarUrl),
                 ),
                 SadRealityRequest.SadRealityUser(
                     when (theFirstLoverGender) {
@@ -211,7 +294,7 @@ class SadRealityExecutor(
                         }
                     },
                     user4.tag,
-                    URLImageData(user4.avatar.url),
+                    URLImageData(user4.avatarUrl),
                 ),
                 SadRealityRequest.SadRealityUser(
                     when (theBestFriendGender) {
@@ -227,7 +310,7 @@ class SadRealityExecutor(
                         }
                     },
                     user5.tag,
-                    URLImageData(user5.avatar.url),
+                    URLImageData(user5.avatarUrl),
                 ),
                 SadRealityRequest.SadRealityUser(
                     when (youGender) {
@@ -236,7 +319,7 @@ class SadRealityExecutor(
                         Gender.UNKNOWN -> context.i18nContext.get(SadRealityCommand.I18N_PREFIX.Slot.You.Male)
                     },
                     user6.tag,
-                    URLImageData(user6.avatar.url),
+                    URLImageData(user6.avatarUrl),
                 )
             )
         )
@@ -249,6 +332,6 @@ class SadRealityExecutor(
     data class SadRealityUser(
         val id: Snowflake,
         val tag: String,
-        val avatar: UserAvatar
+        val avatarUrl: String
     )
 }

--- a/discord/discord-common/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/LorittaCinnamon.kt
+++ b/discord/discord-common/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/LorittaCinnamon.kt
@@ -81,7 +81,7 @@ abstract class LorittaCinnamon(
             UserId(user.id.value),
             user.name,
             user.discriminator,
-            user.avatar.avatarId
+            user.avatarHash
         )
     }
 

--- a/discord/discord-common/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/SlashCommandExecutorWrapper.kt
+++ b/discord/discord-common/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/SlashCommandExecutorWrapper.kt
@@ -2,6 +2,7 @@ package net.perfectdreams.loritta.cinnamon.platform.commands
 
 import dev.kord.common.entity.DiscordAttachment
 import dev.kord.common.entity.Snowflake
+import dev.kord.rest.Image
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -16,6 +17,7 @@ import mu.KotlinLogging
 import net.perfectdreams.discordinteraktions.common.commands.ApplicationCommandContext
 import net.perfectdreams.discordinteraktions.common.commands.GuildApplicationCommandContext
 import net.perfectdreams.discordinteraktions.common.commands.options.SlashCommandArguments
+import net.perfectdreams.discordinteraktions.common.entities.Icon
 import net.perfectdreams.discordinteraktions.common.entities.User
 import net.perfectdreams.discordinteraktions.common.entities.UserAvatar
 import net.perfectdreams.discordinteraktions.common.requests.InteractionRequestState
@@ -229,12 +231,17 @@ class SlashCommandExecutorWrapper(
                             )
 
                             if (cachedUserInfo != null) {
-                                val userAvatar = UserAvatar(
-                                    cachedUserInfo.id.value,
-                                    cachedUserInfo.discriminator.toInt(),
-                                    cachedUserInfo.avatarId
-                                )
-                                cinnamonArgs[it] = URLImageReference(userAvatar.url)
+                                val icon = cachedUserInfo.avatarId?.let {
+                                    Icon.UserAvatar(
+                                        Snowflake(cachedUserInfo.id.value),
+                                        it
+                                    )
+                                } ?: Icon.DefaultUserAvatar(cachedUserInfo.discriminator.toInt())
+
+                                cinnamonArgs[it] = URLImageReference(icon.cdnUrl.toUrl {
+                                    this.format = Image.Format.PNG
+                                    this.size = Image.Size.Size128
+                                })
                                 found = true
                             }
 

--- a/discord/discord-common/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/utils/ContextStringToUserInfoConverter.kt
+++ b/discord/discord-common/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/utils/ContextStringToUserInfoConverter.kt
@@ -22,7 +22,7 @@ object ContextStringToUserInfoConverter {
                 UserId(user.id.value),
                 user.name,
                 user.discriminator,
-                user.avatar.avatarId
+                user.avatarHash
             )
         }
 

--- a/resources/languages/en/commands/user.yml
+++ b/resources/languages/en/commands/user.yml
@@ -12,6 +12,9 @@ avatar:
   kuraminhaEasterEgg: "The cutest fox... and bot, out there!"
   openAvatarInBrowser: "Open avatar in browser" # Used in a button, when clicking the button, Discord opens the user's avatar in the user's browser
 
+  viewUserGuildProfileAvatar: "View the user's guild profile avatar"
+  viewUserGlobalAvatar: "View the user's global avatar"
+
   options:
     user: "The user that you want to steal... I mean, view, their avatar (*/ω＼*)"
 


### PR DESCRIPTION
Fixes #2530

For now only avatar switching is implemented.

Changes were also made in other classes, because Discord InteraKTions was updated to handle members' avatars.

![DiscordCanary_XjPuTB2KVu](https://user-images.githubusercontent.com/9496359/159589852-a8950c8f-8466-4b69-b17b-47716c860df6.gif)

