### PR TITLE
Add `/user info`, add Discord entities caching

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,7 +4,7 @@ object Versions {
     const val JVM_TARGET = "15"
     const val PROMETHEUS = "0.12.0"
     const val KTOR = "2.0.0"
-    const val DISCORD_INTERAKTIONS = "0.0.14-20220510.143718-1"
+    const val DISCORD_INTERAKTIONS = "0.0.14-20220526.153846-2"
     const val KORD = "0.8.x-20220414.234246-171" // Should match Discord InteraKTions
     const val KOTLINX_DATE_TIME = "0.3.1"
 }

--- a/common/src/commonMain/kotlin/net/perfectdreams/loritta/cinnamon/common/emotes/Emotes.kt
+++ b/common/src/commonMain/kotlin/net/perfectdreams/loritta/cinnamon/common/emotes/Emotes.kt
@@ -41,9 +41,11 @@ object Emotes {
     val LoriHi = DiscordEmote(972187812554211418L, "lori_hi", false)
     val LoriPunch = DiscordEmote(731871119400894525L, "lori_fight", true)
     val LoriSleeping = DiscordEmote(964701978091470919L, "lori_zz", false)
+    val LoriAngel = DiscordEmote(964701052324675622L, "lori_angel", false)
 
     val PantufaGaming = DiscordEmote(853048446922784819L, "pantufa_gaming", false)
 
+    val CheckMark = UnicodeEmote("✅")
     val Error = DiscordEmote(412585701054611458L, "error", false)
 
     val CoinHeads = DiscordEmote(412586256409559041, "cara", false)
@@ -142,7 +144,9 @@ object Emotes {
     val UndertaleAsgoreNeutral = DiscordEmote(890641728313368596L, "ut_asgore_neutral", false)
     val UndertaleAsrielNeutral = DiscordEmote(890641811771646015L, "ut_asriel_neutral", false)
 
-    val BotTag = DiscordEmote(516314838541008906L, "bot", false)
+    val BotTag = DiscordEmote(979198875556532224L, "bot", false)
+    val VerifiedBotTag = DiscordEmote(979198875040624691L, "verified_bot", false)
+    val VerifiedSystemTag = DiscordEmote(979199657546772520L, "verified_system", false)
     val WumpusBasic = DiscordEmote(516315292821880832L, "wumpus_basic", false)
     val DiscordEmployee = DiscordEmote(718883109428396114L, "discord_staff", false)
     val DiscordPartner = DiscordEmote(776925307269283862L, "discord_partner", false)
@@ -154,6 +158,7 @@ object Emotes {
     val EarlySupporter = DiscordEmote(718884313290113095L, "early_supporter", false)
     val BugHunterLevel2 = DiscordEmote(776924915055722507L, "bug_hunter_lvl_2", false)
     val VerifiedBotDeveloper = DiscordEmote(718883878378668112L, "verified_developer", false)
+    val Http = DiscordEmote(979202576878829628L, "http", false)
 
     val ChevronLeft = DiscordEmote(930922528715722782L, "chevron_left", false)
     val ChevronRight = DiscordEmote(930922702011773038L, "chevron_right", false)

--- a/common/src/commonMain/kotlin/net/perfectdreams/loritta/cinnamon/common/utils/JsonIgnoreMissingFields.kt
+++ b/common/src/commonMain/kotlin/net/perfectdreams/loritta/cinnamon/common/utils/JsonIgnoreMissingFields.kt
@@ -1,0 +1,5 @@
+package net.perfectdreams.loritta.cinnamon.common.utils
+
+import kotlinx.serialization.json.Json
+
+val JsonIgnoreUnknownKeys = Json { ignoreUnknownKeys = true }

--- a/common/src/commonMain/kotlin/net/perfectdreams/loritta/cinnamon/common/utils/LorittaColors.kt
+++ b/common/src/commonMain/kotlin/net/perfectdreams/loritta/cinnamon/common/utils/LorittaColors.kt
@@ -3,6 +3,8 @@ package net.perfectdreams.loritta.cinnamon.common.utils
 object LorittaColors {
     val LorittaAqua = Color(26, 160, 254)
     val LorittaRed = Color(255, 96, 71)
+    val DiscordBlurple = Color(88, 101, 242)
+    val DiscordOldBlurple = Color(110, 133, 211)
     val CorreiosYellow = Color(253, 220, 1)
     val RobloxRed = Color(226, 34, 26)
 }

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/CommandManager.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/CommandManager.kt
@@ -57,7 +57,11 @@ import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations.ServerCommand
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations.UserAvatarUserCommand
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations.UserCommand
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations.UserInfoUserCommand
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations.WebhookCommand
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.info.ShowGuildMemberPermissionsExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.info.UserInfoSlashExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.info.UserInfoUserExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.webhook.WebhookEditJsonExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.webhook.WebhookEditRepostExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.webhook.WebhookEditSimpleExecutor
@@ -282,6 +286,7 @@ class CommandManager(
         commandManager.register(
             UserCommand,
             UserAvatarSlashExecutor(Snowflake(discordConfig.applicationId)),
+            UserInfoSlashExecutor(http),
             UserBannerExecutor(rest)
         )
 
@@ -298,6 +303,16 @@ class CommandManager(
         commandManager.register(
             SwitchToGlobalAvatarExecutor,
             SwitchToGlobalAvatarExecutor(loritta, Snowflake(discordConfig.applicationId))
+        )
+
+        commandManager.register(
+            UserInfoUserCommand,
+            UserInfoUserExecutor(http)
+        )
+
+        commandManager.register(
+            ShowGuildMemberPermissionsExecutor,
+            ShowGuildMemberPermissionsExecutor()
         )
 
         commandManager.register(

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/ComponentExecutorIds.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/ComponentExecutorIds.kt
@@ -33,6 +33,7 @@ object ComponentExecutorIds {
     val RETRIBUTE_ATTACK_BUTTON_EXECUTOR = register("0022")
     val RETRIBUTE_DANCE_BUTTON_EXECUTOR = register("0023")
     val RETRIBUTE_KISS_BUTTON_EXECUTOR = register("0024")
+    val SHOW_GUILD_MEMBER_PERMISSIONS_BUTTON_EXECUTOR = register("0025")
 
     /**
      * Verifies if the [id] matches our constraints

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/MessageTargetType.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/MessageTargetType.kt
@@ -1,0 +1,7 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord.avatar
+
+enum class MessageTargetType {
+    SEND_MESSAGE_PUBLIC,
+    SEND_MESSAGE_EPHEMERAL,
+    EDIT_MESSAGE
+}

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/SwitchToGlobalAvatarExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/SwitchToGlobalAvatarExecutor.kt
@@ -38,8 +38,16 @@ class SwitchToGlobalAvatarExecutor(val loritta: LorittaCinnamon, val lorittaId: 
             newData
         )
 
-        context.updateMessage {
-            message()
+        when (decodedInteractionData.targetType) {
+            MessageTargetType.SEND_MESSAGE_PUBLIC -> context.sendMessage {
+                message()
+            }
+            MessageTargetType.SEND_MESSAGE_EPHEMERAL -> context.sendEphemeralMessage {
+                message()
+            }
+            MessageTargetType.EDIT_MESSAGE -> context.updateMessage {
+                message()
+            }
         }
     }
 }

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/SwitchToGuildProfileAvatarExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/SwitchToGuildProfileAvatarExecutor.kt
@@ -35,8 +35,16 @@ class SwitchToGuildProfileAvatarExecutor(val loritta: LorittaCinnamon, val lorit
             newData
         )
 
-        context.updateMessage {
-            message()
+        when (decodedInteractionData.targetType) {
+            MessageTargetType.SEND_MESSAGE_PUBLIC -> context.sendMessage {
+                message()
+            }
+            MessageTargetType.SEND_MESSAGE_EPHEMERAL -> context.sendEphemeralMessage {
+                message()
+            }
+            MessageTargetType.EDIT_MESSAGE -> context.updateMessage {
+                message()
+            }
         }
     }
 }

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/UserAvatarExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/UserAvatarExecutor.kt
@@ -45,6 +45,7 @@ interface UserAvatarExecutor {
                 context.user.id,
                 user.id,
                 (context as? GuildApplicationCommandContext)?.guildId,
+                MessageTargetType.EDIT_MESSAGE,
                 id
             ),
             data

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/UserDataUtils.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/avatar/UserDataUtils.kt
@@ -239,6 +239,7 @@ object UserDataUtils {
         override val userId: Snowflake,
         val viewingAvatarOfId: Snowflake,
         val guildId: Snowflake?,
+        val targetType: MessageTargetType,
         val interactionDataId: Long
     ) : SingleUserComponentData
 

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/declarations/UserCommand.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/declarations/UserCommand.kt
@@ -6,16 +6,21 @@ import net.perfectdreams.loritta.cinnamon.platform.commands.CommandCategory
 import net.perfectdreams.loritta.cinnamon.platform.commands.SlashCommandDeclarationWrapper
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.UserBannerExecutor
 import net.perfectdreams.loritta.cinnamon.platform.commands.discord.avatar.UserAvatarSlashExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.info.UserInfoSlashExecutor
 
 object UserCommand : SlashCommandDeclarationWrapper {
     val I18N_PREFIX = I18nKeysData.Commands.Command.User
 
-    override fun declaration() = slashCommand(listOf("user"), CommandCategory.DISCORD, TodoFixThisData) {
-        subcommand(listOf("avatar"), I18nKeysData.Commands.Command.User.Avatar.Description) {
+    override fun declaration() = slashCommand(listOf("user"), CommandCategory.DISCORD, I18N_PREFIX.Info.ViewUserInfo) {
+        subcommand(listOf("avatar"), TodoFixThisData) {
             executor = UserAvatarSlashExecutor
         }
 
-        subcommand(listOf("banner"), I18nKeysData.Commands.Command.User.Banner.Description) {
+        subcommand(listOf("info"), I18N_PREFIX.Avatar.Description) {
+            executor = UserInfoSlashExecutor
+        }
+
+        subcommand(listOf("banner"), I18N_PREFIX.Banner.Description) {
             executor = UserBannerExecutor
         }
     }

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/declarations/UserInfoUserCommand.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/declarations/UserInfoUserCommand.kt
@@ -1,0 +1,9 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations
+
+import net.perfectdreams.loritta.cinnamon.platform.commands.UserCommandDeclarationWrapper
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.info.UserInfoUserExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.userCommand
+
+object UserInfoUserCommand : UserCommandDeclarationWrapper {
+    override fun declaration() = userCommand(UserCommand.I18N_PREFIX.Info.ViewUserInfo, UserInfoUserExecutor)
+}

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/GuildMemberPermissionsData.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/GuildMemberPermissionsData.kt
@@ -1,0 +1,11 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord.info
+
+import dev.kord.common.entity.Permissions
+import dev.kord.common.entity.Snowflake
+
+@kotlinx.serialization.Serializable
+data class GuildMemberPermissionsData(
+    val roles: List<Snowflake>,
+    val permissions: Permissions,
+    val color: Int?
+)

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/ShowGuildMemberPermissionsExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/ShowGuildMemberPermissionsExecutor.kt
@@ -1,0 +1,60 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord.info
+
+import dev.kord.common.Color
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
+import net.perfectdreams.discordinteraktions.common.builder.message.embed
+import net.perfectdreams.discordinteraktions.common.entities.User
+import net.perfectdreams.discordinteraktions.common.utils.field
+import net.perfectdreams.loritta.cinnamon.common.emotes.Emotes
+import net.perfectdreams.loritta.cinnamon.i18n.I18nKeysData
+import net.perfectdreams.loritta.cinnamon.platform.commands.ComponentExecutorIds
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations.UserCommand
+import net.perfectdreams.loritta.cinnamon.platform.commands.styled
+import net.perfectdreams.loritta.cinnamon.platform.components.ButtonClickExecutorDeclaration
+import net.perfectdreams.loritta.cinnamon.platform.components.ButtonClickWithDataExecutor
+import net.perfectdreams.loritta.cinnamon.platform.components.ComponentContext
+import net.perfectdreams.loritta.cinnamon.platform.utils.ComponentDataUtils
+import net.perfectdreams.loritta.cinnamon.platform.utils.RawToFormated.toLocalized
+import net.perfectdreams.loritta.cinnamon.platform.utils.StoredGenericInteractionData
+
+class ShowGuildMemberPermissionsExecutor : ButtonClickWithDataExecutor {
+    companion object : ButtonClickExecutorDeclaration(ComponentExecutorIds.SHOW_GUILD_MEMBER_PERMISSIONS_BUTTON_EXECUTOR)
+
+    override suspend fun onClick(user: User, context: ComponentContext, data: String) {
+        val decodedInteractionData = ComponentDataUtils.decode<StoredGenericInteractionData>(data)
+        val interactionDataFromDatabase = Json.decodeFromJsonElement<GuildMemberPermissionsData>(
+            context.loritta.services.interactionsData.getInteractionData(decodedInteractionData.interactionDataId) ?: context.failEphemerally {
+                styled(
+                    context.i18nContext.get(I18nKeysData.Commands.InteractionDataIsMissingFromDatabaseGeneric),
+                    Emotes.LoriSleeping
+                )
+            }
+        )
+
+        context.sendEphemeralMessage {
+            embed {
+                field(
+                    "${Emotes.LoriSunglasses} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.Roles)}",
+                    interactionDataFromDatabase.roles.joinToString { "<@&${it}>" },
+                    false
+                )
+
+                val permissionList = interactionDataFromDatabase.permissions.values.toLocalized()?.joinToString(
+                    ", ",
+                    transform = { "`${context.i18nContext.get(it)}`" }
+                )
+
+                if (permissionList != null) {
+                    field(
+                        "${Emotes.LoriAngel} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.Permissions)}",
+                        permissionList,
+                        false
+                    )
+                }
+
+                color = interactionDataFromDatabase.color?.let { Color(it) }
+            }
+        }
+    }
+}

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/UserInfoExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/UserInfoExecutor.kt
@@ -1,0 +1,457 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord.info
+
+import dev.kord.common.Color
+import dev.kord.common.DiscordBitSet
+import dev.kord.common.entity.ButtonStyle
+import dev.kord.common.entity.Permissions
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.UserFlag
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.datetime.Clock
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import net.perfectdreams.discordinteraktions.common.builder.message.MessageBuilder
+import net.perfectdreams.discordinteraktions.common.builder.message.actionRow
+import net.perfectdreams.discordinteraktions.common.builder.message.embed
+import net.perfectdreams.discordinteraktions.common.entities.InteractionMember
+import net.perfectdreams.discordinteraktions.common.entities.Member
+import net.perfectdreams.discordinteraktions.common.entities.User
+import net.perfectdreams.discordinteraktions.common.utils.author
+import net.perfectdreams.discordinteraktions.common.utils.field
+import net.perfectdreams.discordinteraktions.common.utils.thumbnailUrl
+import net.perfectdreams.discordinteraktions.platforms.kord.entities.KordUser
+import net.perfectdreams.loritta.cinnamon.common.emotes.Emotes
+import net.perfectdreams.loritta.cinnamon.common.utils.LorittaColors
+import net.perfectdreams.loritta.cinnamon.i18n.I18nKeysData
+import net.perfectdreams.loritta.cinnamon.platform.commands.ApplicationCommandContext
+import net.perfectdreams.loritta.cinnamon.platform.commands.GuildApplicationCommandContext
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.avatar.MessageTargetType
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.avatar.SwitchToGlobalAvatarExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.avatar.UserDataUtils
+import net.perfectdreams.loritta.cinnamon.platform.commands.discord.declarations.UserCommand
+import net.perfectdreams.loritta.cinnamon.platform.components.interactiveButton
+import net.perfectdreams.loritta.cinnamon.platform.utils.ComponentDataUtils
+import net.perfectdreams.loritta.cinnamon.platform.utils.StoredGenericInteractionData
+import net.perfectdreams.loritta.cinnamon.platform.utils.toKordColor
+import kotlin.time.Duration.Companion.minutes
+
+interface UserInfoExecutor {
+    val http: HttpClient
+
+    suspend fun handleUserExecutor(
+        context: ApplicationCommandContext,
+        user: User,
+        member: Member?,
+        isEphemeral: Boolean,
+    ) {
+        val now = Clock.System.now()
+
+        // Hack!
+        val publicFlags = (user as KordUser).handle.publicFlags
+            .value
+
+        val flags = publicFlags?.flags ?: emptyList()
+        val flagsToEmotes = flags.mapNotNull {
+            when (it) {
+                UserFlag.DiscordEmployee -> Emotes.DiscordEmployee
+                UserFlag.DiscordPartner -> Emotes.DiscordPartner
+                UserFlag.HypeSquad -> Emotes.HypeSquad
+                UserFlag.BugHunterLevel1 -> Emotes.BugHunterLevel1
+                UserFlag.HouseBravery -> Emotes.HouseBravery
+                UserFlag.HouseBrilliance -> Emotes.HouseBrilliance
+                UserFlag.HouseBalance -> Emotes.HouseBalance
+                UserFlag.EarlySupporter -> Emotes.EarlySupporter
+                // I don't know how we could represent this
+                // UserFlag.TeamUser -> ???
+                UserFlag.BugHunterLevel2 -> Emotes.BugHunterLevel2
+                UserFlag.VerifiedBotDeveloper -> Emotes.VerifiedBotDeveloper
+                UserFlag.DiscordCertifiedModerator -> Emotes.LoriCoffee
+                else -> null
+            }
+        }
+
+        // Discord's System User (643945264868098049) does not have the "System" flag, so we will add a special handling for it
+        val isSystemUser = UserFlag.System in flags || (user.name == "Discord" && user.discriminator == "0000")
+
+        // Get application information
+        val applicationInfo = if (user.bot && !isSystemUser) {
+            // It looks like system user do not have an application bound to it, so we will just ignore it
+            getApplicationInfo(user.id)
+        } else null
+
+        val roles = if (context is GuildApplicationCommandContext && member != null)
+            context.loritta.cache.getRoles(
+                context.guildId,
+                member.roles
+            )
+        else null
+
+        val topRole = roles?.maxByOrNull { it.position }
+        // Did you know that you can't have a fully black role on Discord? The color "0" is used for "not set"!
+        val topRoleForColor = roles?.filter { it.color != 0 }?.maxByOrNull { it.position }
+
+        val message: suspend MessageBuilder.() -> (Unit) = {
+            embed {
+                author(context.i18nContext.get(UserCommand.I18N_PREFIX.Info.InfoAboutTheUser))
+                title = buildString {
+                    if (user.bot) {
+                        append(
+                            when {
+                                isSystemUser -> Emotes.VerifiedSystemTag
+                                UserFlag.VerifiedBot in flags -> Emotes.VerifiedBotTag
+                                else -> Emotes.BotTag
+                            }
+                        )
+                    } else {
+                        append(Emotes.WumpusBasic)
+                    }
+
+                    if (flagsToEmotes.isNotEmpty()) {
+                        for (emote in flagsToEmotes)
+                            append(emote.toString())
+                    }
+
+                    append(" ")
+
+                    append(user.name)
+                }
+                url = "https://discord.com/users/${user.id}"
+
+                field("\uD83D\uDCBB ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.User.DiscordId)}", "`${user.id}`", true)
+                field("\uD83C\uDFF7️ ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.User.DiscordTag)}", "`${user.name}#${user.discriminator}`", true)
+                field("\uD83D\uDCC5 ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.User.AccountCreationDate)}", "<t:${user.id.timestamp.epochSeconds}:f> (<t:${user.id.timestamp.epochSeconds}:R>)", true)
+
+                thumbnailUrl = user.avatar.cdnUrl.toUrl()
+                color = LorittaColors.DiscordBlurple.toKordColor()
+            }
+
+            if (member != null) {
+                val communicationDisabledUntil = member.communicationDisabledUntil
+
+                embed {
+                    author(context.i18nContext.get(UserCommand.I18N_PREFIX.Info.InfoAboutTheMember))
+                    title = member.nick ?: user.name
+
+                    field(
+                        "\uD83D\uDCC5 ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.AccountJoinDate)}",
+                        "<t:${member.joinedAt.epochSeconds}:f> (<t:${member.joinedAt.epochSeconds}:R>)",
+                        true
+                    )
+
+                    if (communicationDisabledUntil != null) {
+                        field(
+                            "${Emotes.LoriBonk} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.TimedOutUntil)}",
+                            buildString {
+                                append("<t:${member.communicationDisabledUntil?.epochSeconds}:f> (<t:${member.communicationDisabledUntil?.epochSeconds}:R>)")
+                                if (Clock.System.now() > communicationDisabledUntil) {
+                                    append("\n")
+                                    append("*(${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.TimeoutTip)})*")
+                                }
+                            },
+                            true
+                        )
+                    }
+
+                    val premiumSince = member.premiumSince
+
+                    if (premiumSince != null) {
+                        field(
+                            "${Emotes.LoriWow} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.BoostingSince)}",
+                            "<t:${premiumSince.epochSeconds}:f> (<t:${premiumSince.epochSeconds}:R>)",
+                            true
+                        )
+                    }
+
+                    if (topRole != null) {
+                        field(
+                            "${Emotes.LoriSunglasses} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.HighestRole)}",
+                            "<@&${topRole.id}>",
+                            true
+                        )
+
+                        color = topRoleForColor?.let { Color(it.color) }
+                    }
+
+                    field(
+                        "${Emotes.LoriZap} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.InterestingTidbits)}",
+                        """${fancify(!member.pending)} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.CompletedMembershipScreening)}
+                                |${fancify(communicationDisabledUntil != null && communicationDisabledUntil >= Clock.System.now())} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.IsTimedOut)}
+                            """.trimMargin(),
+                        false
+                    )
+
+                    thumbnailUrl = (member.avatar ?: user.avatar).cdnUrl.toUrl()
+                }
+            }
+
+            if (user.bot && !isSystemUser) {
+                embed {
+                    author(context.i18nContext.get(UserCommand.I18N_PREFIX.Info.InfoAboutTheApplication))
+
+                    if (applicationInfo != null) {
+                        title = applicationInfo.name
+                        description = applicationInfo.description
+
+                        if (applicationInfo.guildId != null) {
+                            field(
+                                "\uD83D\uDCBB ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.SupportGuildId)}",
+                                "`${applicationInfo.guildId}`",
+                                true
+                            )
+                        }
+
+                        val tags = applicationInfo.tags
+                        if (tags != null) {
+                            field(
+                                "\uD83C\uDFF7️ ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.Tags)}",
+                                tags.joinToString(),
+                                true
+                            )
+                        }
+
+                        if (applicationInfo.slug != null) {
+                            field(
+                                "\uD83D\uDC1B ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.Slug)}",
+                                "`${applicationInfo.slug}`",
+                                true
+                            )
+                        }
+
+                        val bitSet = DiscordBitSet(applicationInfo.flags.toString())
+                        val hasGatewayPresence = bitSet.contains(DiscordBitSet(1 shl 12))
+                        val hasGatewayPresenceLimited = bitSet.contains(DiscordBitSet(1 shl 13))
+                        val hasGuildMembers = bitSet.contains(DiscordBitSet(1 shl 14))
+                        val hasGuildMembersLimited = bitSet.contains(DiscordBitSet(1 shl 15))
+                        // val verificationPendingGuildLimit = bitSet.contains(DiscordBitSet(1 shl 16))
+                        val hasGatewayMessageContent = bitSet.contains(DiscordBitSet(1 shl 18))
+                        val hasGatewayMessageContentLimited = bitSet.contains(DiscordBitSet(1 shl 19))
+
+                        // While it would be nice to show the "Bot is actually using the intent but it is in less than 100 servers", it is not that reliable.
+                        // Loritta has the "hasGuildMembersLimited" intent, however she is in more than 100 guilds
+                        field(
+                            "${Emotes.LoriZap} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.InterestingTidbits)}",
+                            """${fancify(applicationInfo.botPublic)} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.Public)}
+                                |${fancify(applicationInfo.botRequireCodeGrant)} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.RequiresOAuth2CodeGrant)}
+                                |${fancify(UserFlag.BotHttpInteractions in flags)} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.UsesInteractionsOverHttp)}
+                                |${fancify(hasGatewayPresence || hasGatewayPresenceLimited)} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.IntentGatewayPresences)}
+                                |${fancify(hasGuildMembers || hasGuildMembersLimited)} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.IntentGuildMembers)}
+                                |${fancify(hasGatewayMessageContent || hasGatewayMessageContentLimited)} ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.IntentMessageContent)}
+                            """.trimMargin(),
+                            false
+                        )
+
+                        field(
+                            "\uD83D\uDCBB ${context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.PublicKey)}",
+                            "`${applicationInfo.verifyKey}`",
+                            false
+                        )
+
+                        if (applicationInfo.icon != null)
+                            thumbnailUrl = "https://cdn.discordapp.com/app-icons/${applicationInfo.id}/${applicationInfo.icon}.png"
+
+                        color = LorittaColors.DiscordOldBlurple.toKordColor()
+                    } else {
+                        title = "${Emotes.Error} Whoops"
+                        description = context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.NoMatchingApplicationFound)
+                    }
+                }
+            }
+
+            val loritta = context.loritta
+
+            // ===[ VIEW AVATAR BUTTONS ]===
+            actionRow {
+                // ===[ GLOBAL AVATAR ]===
+                val globalInteractionId = loritta.services.interactionsData.insertInteractionData(
+                    Json.encodeToJsonElement<UserDataUtils.ViewingUserAvatarData>(
+                        UserDataUtils.ViewingGlobalUserAvatarData(
+                            user.name,
+                            user.discriminator.toInt(),
+                            user.avatarHash,
+                            member?.avatarHash
+                        )
+                    ).jsonObject,
+                    now,
+                    now + 15.minutes // Expires after 15m
+                )
+
+                interactiveButton(
+                    ButtonStyle.Primary,
+                    SwitchToGlobalAvatarExecutor,
+                    ComponentDataUtils.encode(
+                        UserDataUtils.SwitchAvatarInteractionIdData(
+                            context.user.id,
+                            user.id,
+                            (context as? GuildApplicationCommandContext)?.guildId,
+                            if (isEphemeral) MessageTargetType.SEND_MESSAGE_EPHEMERAL else MessageTargetType.SEND_MESSAGE_PUBLIC,
+                            globalInteractionId
+                        )
+                    )
+                ) {
+                    label = context.i18nContext.get(I18nKeysData.Innercommands.Innercommand.Inneruser.Inneravatar.ViewUserGlobalAvatar)
+                }
+
+                // ===[ GUILD AVATAR ]===
+                val guildAvatarHash = member?.avatarHash
+                if (guildAvatarHash != null) {
+                    val localInteractionId = loritta.services.interactionsData.insertInteractionData(
+                        Json.encodeToJsonElement<UserDataUtils.ViewingUserAvatarData>(
+                            UserDataUtils.ViewingGuildProfileUserAvatarData(
+                                user.name,
+                                user.discriminator.toInt(),
+                                user.avatarHash,
+                                guildAvatarHash
+                            )
+                        ).jsonObject,
+                        now,
+                        now + 15.minutes // Expires after 15m
+                    )
+
+                    interactiveButton(
+                        ButtonStyle.Primary,
+                        SwitchToGlobalAvatarExecutor,
+                        ComponentDataUtils.encode(
+                            UserDataUtils.SwitchAvatarInteractionIdData(
+                                context.user.id,
+                                user.id,
+                                (context as? GuildApplicationCommandContext)?.guildId,
+                                if (isEphemeral) MessageTargetType.SEND_MESSAGE_EPHEMERAL else MessageTargetType.SEND_MESSAGE_PUBLIC,
+                                localInteractionId
+                            )
+                        )
+                    ) {
+                        label = context.i18nContext.get(I18nKeysData.Innercommands.Innercommand.Inneruser.Inneravatar.ViewUserGuildProfileAvatar)
+                    }
+                }
+            }
+
+            if (member != null && member is InteractionMember) {
+                actionRow {
+                    val memberPermissionsInteractionId = loritta.services.interactionsData.insertInteractionData(
+                        Json.encodeToJsonElement(
+                            GuildMemberPermissionsData(
+                                member.roles,
+                                member.permissions,
+                                topRoleForColor?.color
+                            )
+                        ).jsonObject,
+                        now,
+                        now + 15.minutes // Expires after 15m
+                    )
+
+                    interactiveButton(
+                        ButtonStyle.Primary,
+                        ShowGuildMemberPermissionsExecutor,
+                        ComponentDataUtils.encode(
+                            StoredGenericInteractionData(
+                                memberPermissionsInteractionId
+                            )
+                        )
+                    ) {
+                        label = context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Member.MemberPermissions)
+                    }
+                }
+            }
+
+            val inviteUrl = applicationInfo?.customInstallUrl ?: if (applicationInfo?.installParams != null) {
+                "https://discord.com/api/oauth2/authorize?client_id=${applicationInfo.id}&scope=${applicationInfo.installParams.scopes.joinToString("+")}&permissions=${applicationInfo.installParams.permissions.code}"
+            } else null
+
+            val termsOfServiceUrl = applicationInfo?.termsOfServiceUrl
+            val privacyPolicyUrl = applicationInfo?.privacyPolicyUrl
+
+            if (inviteUrl != null || termsOfServiceUrl != null || privacyPolicyUrl != null) {
+                actionRow {
+                    if (applicationInfo?.botPublic == true) {
+                        if (inviteUrl != null) {
+                            linkButton(inviteUrl) {
+                                label = context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.AddToServer)
+                            }
+                        }
+                    }
+
+                    if (termsOfServiceUrl != null) {
+                        linkButton(termsOfServiceUrl) {
+                            label = context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.TermsOfService)
+                        }
+                    }
+
+                    if (privacyPolicyUrl != null) {
+                        linkButton(privacyPolicyUrl) {
+                            label = context.i18nContext.get(UserCommand.I18N_PREFIX.Info.Application.PrivacyPolicy)
+                        }
+                    }
+                }
+            }
+        }
+
+        if (isEphemeral) {
+            context.sendEphemeralMessage {
+                message()
+            }
+        } else {
+            context.sendMessage {
+                message()
+            }
+        }
+    }
+
+    private fun fancify(bool: Boolean) =
+        if (bool)
+            Emotes.CheckMark
+        else
+            Emotes.Error
+
+    suspend fun getApplicationInfo(snowflake: Snowflake): ApplicationInfo? {
+        val applicationInfoResponse = http.get("https://discord.com/api/v10/applications/$snowflake/rpc")
+
+        if (applicationInfoResponse.status != HttpStatusCode.OK)
+            return null
+
+        return Json { ignoreUnknownKeys = true }.decodeFromString(applicationInfoResponse.bodyAsText())
+    }
+
+    @kotlinx.serialization.Serializable
+    data class ApplicationInfo(
+        val id: Snowflake,
+        val name: String,
+        val icon: String? = null,
+        val description: String,
+        val type: Int?,
+        @SerialName("cover_image")
+        val coverImage: String? = null,
+        @SerialName("primary_sku_id")
+        val primarySkuId: String? = null,
+        val slug: String? = null,
+        @SerialName("guild_id")
+        val guildId: Snowflake? = null,
+        @SerialName("bot_public")
+        val botPublic: Boolean,
+        @SerialName("bot_require_code_grant")
+        val botRequireCodeGrant: Boolean,
+        @SerialName("custom_install_url")
+        val customInstallUrl: String? = null,
+        @SerialName("install_params")
+        val installParams: InstallParams? = null,
+        @SerialName("verify_key")
+        val verifyKey: String,
+        @SerialName("terms_of_service_url")
+        val termsOfServiceUrl: String? = null,
+        @SerialName("privacy_policy_url")
+        val privacyPolicyUrl: String? = null,
+        val flags: Long,
+        val tags: List<String>? = null
+    )
+
+    @kotlinx.serialization.Serializable
+    data class InstallParams(
+        val scopes: List<String>,
+        val permissions: Permissions
+    )
+}

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/UserInfoExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/UserInfoExecutor.kt
@@ -27,6 +27,7 @@ import net.perfectdreams.discordinteraktions.common.utils.field
 import net.perfectdreams.discordinteraktions.common.utils.thumbnailUrl
 import net.perfectdreams.discordinteraktions.platforms.kord.entities.KordUser
 import net.perfectdreams.loritta.cinnamon.common.emotes.Emotes
+import net.perfectdreams.loritta.cinnamon.common.utils.JsonIgnoreUnknownKeys
 import net.perfectdreams.loritta.cinnamon.common.utils.LorittaColors
 import net.perfectdreams.loritta.cinnamon.i18n.I18nKeysData
 import net.perfectdreams.loritta.cinnamon.platform.commands.ApplicationCommandContext
@@ -414,7 +415,7 @@ interface UserInfoExecutor {
         if (applicationInfoResponse.status != HttpStatusCode.OK)
             return null
 
-        return Json { ignoreUnknownKeys = true }.decodeFromString(applicationInfoResponse.bodyAsText())
+        return JsonIgnoreUnknownKeys.decodeFromString(applicationInfoResponse.bodyAsText())
     }
 
     @kotlinx.serialization.Serializable

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/UserInfoSlashExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/UserInfoSlashExecutor.kt
@@ -1,0 +1,39 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord.info
+
+import io.ktor.client.*
+import net.perfectdreams.loritta.cinnamon.common.utils.TodoFixThisData
+import net.perfectdreams.loritta.cinnamon.platform.commands.ApplicationCommandContext
+import net.perfectdreams.loritta.cinnamon.platform.commands.GuildApplicationCommandContext
+import net.perfectdreams.loritta.cinnamon.platform.commands.SlashCommandExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.SlashCommandExecutorDeclaration
+import net.perfectdreams.loritta.cinnamon.platform.commands.options.ApplicationCommandOptions
+import net.perfectdreams.loritta.cinnamon.platform.commands.options.SlashCommandArguments
+
+class UserInfoSlashExecutor(override val http: HttpClient) : SlashCommandExecutor(), UserInfoExecutor {
+    companion object : SlashCommandExecutorDeclaration() {
+        object Options : ApplicationCommandOptions() {
+            val user = optionalUser("user", TodoFixThisData)
+                .register()
+        }
+
+        override val options = Options
+    }
+
+    override suspend fun execute(context: ApplicationCommandContext, args: SlashCommandArguments) {
+        val user = args[Options.user] ?: context.user
+
+        // TODO: Fix this workaround, it would be nice if Discord InteraKTions provided a "UserAndMember" object to us
+        // (Or maybe expose it correctly?)
+        val member = if (user == context.user && context is GuildApplicationCommandContext)
+            context.member
+        else
+            context.interaKTionsContext.data.resolved?.members?.get(user.id)
+
+        handleUserExecutor(
+            context,
+            user,
+            member,
+            false
+        )
+    }
+}

--- a/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/UserInfoUserExecutor.kt
+++ b/discord/commands/src/jvmMain/kotlin/net/perfectdreams/loritta/cinnamon/platform/commands/discord/info/UserInfoUserExecutor.kt
@@ -1,0 +1,25 @@
+package net.perfectdreams.loritta.cinnamon.platform.commands.discord.info
+
+import io.ktor.client.*
+import net.perfectdreams.discordinteraktions.common.entities.InteractionMember
+import net.perfectdreams.discordinteraktions.common.entities.User
+import net.perfectdreams.loritta.cinnamon.platform.commands.ApplicationCommandContext
+import net.perfectdreams.loritta.cinnamon.platform.commands.UserCommandExecutor
+import net.perfectdreams.loritta.cinnamon.platform.commands.UserCommandExecutorDeclaration
+
+class UserInfoUserExecutor(override val http: HttpClient) : UserCommandExecutor(), UserInfoExecutor {
+    companion object : UserCommandExecutorDeclaration()
+
+    override suspend fun execute(
+        context: ApplicationCommandContext,
+        targetUser: User,
+        targetMember: InteractionMember?
+    ) {
+        handleUserExecutor(
+            context,
+            targetUser,
+            targetMember,
+            true
+        )
+    }
+}

--- a/discord/discord-common/build.gradle.kts
+++ b/discord/discord-common/build.gradle.kts
@@ -24,6 +24,11 @@ dependencies {
     api("io.prometheus:simpleclient_hotspot:${Versions.PROMETHEUS}")
     api("io.prometheus:simpleclient_common:${Versions.PROMETHEUS}")
 
+    // Databases
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.exposed.javatime)
+
     // Logback GELF, used for Graylog logging
     implementation("de.siegmar:logback-gelf:3.0.0")
 

--- a/discord/discord-common/src/main/kotlin/net/perfectdreams/loritta/cinnamon/platform/LorittaCinnamon.kt
+++ b/discord/discord-common/src/main/kotlin/net/perfectdreams/loritta/cinnamon/platform/LorittaCinnamon.kt
@@ -6,7 +6,6 @@ import dev.kord.rest.request.KtorRequestException
 import dev.kord.rest.service.RestClient
 import io.ktor.client.*
 import kotlinx.datetime.Clock
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -16,6 +15,7 @@ import net.perfectdreams.discordinteraktions.common.entities.User
 import net.perfectdreams.loritta.cinnamon.common.locale.LanguageManager
 import net.perfectdreams.loritta.cinnamon.common.utils.config.LorittaConfig
 import net.perfectdreams.loritta.cinnamon.platform.utils.ComponentDataUtils
+import net.perfectdreams.loritta.cinnamon.platform.utils.DiscordCacheService
 import net.perfectdreams.loritta.cinnamon.platform.utils.StoredGenericInteractionData
 import net.perfectdreams.loritta.cinnamon.platform.utils.UserUtils
 import net.perfectdreams.loritta.cinnamon.platform.utils.config.DiscordInteractionsConfig
@@ -44,8 +44,8 @@ abstract class LorittaCinnamon(
 ) {
     // TODO: *Really* set a random seed
     val random = Random(0)
-
     val rest = RestClient(discordConfig.token)
+    val cache = DiscordCacheService(services)
 
     /**
      * Gets the current registered commands count
@@ -110,7 +110,6 @@ abstract class LorittaCinnamon(
     /**
      * Encodes the [data] to fit on a button. If it doesn't fit in a button, a [StoredGenericInteractionData] will be encoded instead and the data will be stored on the database.
      */
-    @OptIn(ExperimentalSerializationApi::class)
     suspend inline fun <reified T> encodeDataForComponentOrStoreInDatabase(data: T): String {
         val encoded = ComponentDataUtils.encode(data)
 
@@ -144,7 +143,6 @@ abstract class LorittaCinnamon(
      *
      * This should be used in conjuction with [encodeDataForComponentOrStoreInDatabase]
      */
-    @OptIn(ExperimentalSerializationApi::class)
     suspend inline fun <reified T> decodeDataFromComponentOrFromDatabase(data: String): T? {
         val genericInteractionData = try {
             ComponentDataUtils.decode<StoredGenericInteractionData>(data)

--- a/discord/discord-common/src/main/kotlin/net/perfectdreams/loritta/cinnamon/platform/utils/DiscordCacheService.kt
+++ b/discord/discord-common/src/main/kotlin/net/perfectdreams/loritta/cinnamon/platform/utils/DiscordCacheService.kt
@@ -1,0 +1,35 @@
+package net.perfectdreams.loritta.cinnamon.platform.utils
+
+import dev.kord.common.entity.DiscordRole
+import dev.kord.common.entity.Permissions
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.Optional
+import dev.kord.common.entity.optional.optional
+import net.perfectdreams.loritta.cinnamon.pudding.Pudding
+import net.perfectdreams.loritta.cinnamon.pudding.tables.cache.DiscordGuildRoles
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.select
+
+class DiscordCacheService(private val pudding: Pudding) {
+    suspend fun getRoles(guildId: Snowflake, roleIds: List<Snowflake>): List<DiscordRole> {
+        return pudding.transaction {
+            DiscordGuildRoles.select {
+                (DiscordGuildRoles.guildId eq guildId.toLong()) and (DiscordGuildRoles.roleId inList roleIds.map { it.toLong() })
+            }.map {
+                DiscordRole(
+                    Snowflake(it[DiscordGuildRoles.roleId]),
+                    it[DiscordGuildRoles.name],
+                    it[DiscordGuildRoles.color],
+                    it[DiscordGuildRoles.hoist],
+                    it[DiscordGuildRoles.icon].optional(),
+                    it[DiscordGuildRoles.unicodeEmoji].optional(),
+                    it[DiscordGuildRoles.position],
+                    Permissions(it[DiscordGuildRoles.permissions].toString()),
+                    it[DiscordGuildRoles.managed],
+                    it[DiscordGuildRoles.mentionable],
+                    Optional()
+                )
+            }
+        }
+    }
+}

--- a/discord/discord-common/src/main/kotlin/net/perfectdreams/loritta/cinnamon/platform/utils/PuddingExtensions.kt
+++ b/discord/discord-common/src/main/kotlin/net/perfectdreams/loritta/cinnamon/platform/utils/PuddingExtensions.kt
@@ -9,6 +9,7 @@ import net.perfectdreams.loritta.cinnamon.pudding.data.UserId
 import net.perfectdreams.loritta.cinnamon.pudding.services.UsersService
 
 fun UserId(snowflake: Snowflake) = UserId(snowflake.value)
+fun Snowflake.toLong() = this.value.toLong()
 
 suspend fun UsersService.getUserProfile(user: User) = getUserProfile(UserId(user.id.value))
 suspend fun UsersService.getOrCreateUserProfile(user: User) = getOrCreateUserProfile(UserId(user.id.value))

--- a/microservices/discord-gateway-events-processor/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/discordgatewayeventsprocessor/DiscordGatewayEventsProcessor.kt
+++ b/microservices/discord-gateway-events-processor/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/discordgatewayeventsprocessor/DiscordGatewayEventsProcessor.kt
@@ -13,6 +13,7 @@ import dev.kord.rest.service.RestClient
 import mu.KotlinLogging
 import net.perfectdreams.loritta.cinnamon.common.locale.LanguageManager
 import net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.modules.AddFirstToNewChannelsModule
+import net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.modules.DiscordCacheModule
 import net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.modules.StarboardModule
 import net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.utils.DiscordGatewayEventsProcessorTasks
 import net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.utils.config.RootConfig
@@ -31,6 +32,7 @@ class DiscordGatewayEventsProcessor(
     val rest = RestClient(config.discord.token)
     val starboardModule = StarboardModule(this)
     val addFirstToNewChannelsModule = AddFirstToNewChannelsModule(this)
+    val discordCacheModule = DiscordCacheModule(this)
     val tasks = DiscordGatewayEventsProcessorTasks(this)
 
     fun start() {
@@ -110,6 +112,7 @@ class DiscordGatewayEventsProcessor(
 
         starboardModule.setupConsumer(channel)
         addFirstToNewChannelsModule.setupConsumer(channel)
+        discordCacheModule.setupConsumer(channel)
 
         tasks.start()
     }

--- a/microservices/discord-gateway-events-processor/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/discordgatewayeventsprocessor/modules/DiscordCacheModule.kt
+++ b/microservices/discord-gateway-events-processor/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/discordgatewayeventsprocessor/modules/DiscordCacheModule.kt
@@ -1,0 +1,105 @@
+package net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.modules
+
+import com.rabbitmq.client.Channel
+import dev.kord.common.entity.DiscordRole
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.value
+import dev.kord.gateway.Event
+import dev.kord.gateway.GuildCreate
+import dev.kord.gateway.GuildDelete
+import dev.kord.gateway.GuildRoleCreate
+import dev.kord.gateway.GuildRoleDelete
+import dev.kord.gateway.GuildRoleUpdate
+import mu.KotlinLogging
+import net.perfectdreams.loritta.cinnamon.microservices.discordgatewayeventsprocessor.DiscordGatewayEventsProcessor
+import net.perfectdreams.loritta.cinnamon.platform.utils.toLong
+import net.perfectdreams.loritta.cinnamon.pudding.tables.cache.DiscordGuildRoles
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import pw.forst.exposed.insertOrUpdate
+
+class DiscordCacheModule(private val m: DiscordGatewayEventsProcessor) : ProcessDiscordEventsModule(RABBITMQ_QUEUE) {
+    companion object {
+        const val RABBITMQ_QUEUE = "discord-cache-module"
+        private val logger = KotlinLogging.logger {}
+    }
+
+    override fun setupQueueBinds(channel: Channel) {
+        channel.queueBindToModuleQueue("event.guild-create")
+        channel.queueBindToModuleQueue("event.guild-delete")
+        channel.queueBindToModuleQueue("event.guild-role-create")
+        channel.queueBindToModuleQueue("event.guild-role-update")
+        channel.queueBindToModuleQueue("event.guild-role-delete")
+    }
+
+    override suspend fun processEvent(event: Event) {
+        when (event) {
+            is GuildCreate -> {
+                logger.info { "Howdy ${event.guild.id} (${event.guild.name})! Is unavailable? ${event.guild.unavailable}" }
+                createOrUpdateRoleBulk(event.guild.id, event.guild.roles)
+            }
+            is GuildRoleCreate -> {
+                createOrUpdateRole(event.role.guildId, event.role.role)
+            }
+            is GuildRoleUpdate -> {
+                createOrUpdateRole(event.role.guildId, event.role.role)
+            }
+            is GuildRoleDelete -> {
+                deleteRole(event.role.guildId, event.role.id)
+            }
+            is GuildDelete -> {
+                // If the unavailable field is not set, the user/bot was removed from the guild.
+                if (event.guild.unavailable.value == null) {
+                    logger.info { "Someone removed me @ ${event.guild.id}! :(" }
+                    removeGuildData(event.guild.id)
+                }
+            }
+            else -> {}
+        }
+    }
+
+    private suspend fun createOrUpdateRoleBulk(guildId: Snowflake, roles: List<DiscordRole>) {
+        m.services.transaction {
+            for (role in roles) {
+                _createOrUpdateRole(guildId, role)
+            }
+        }
+    }
+
+    private suspend fun createOrUpdateRole(guildId: Snowflake, role: DiscordRole) {
+        m.services.transaction {
+            _createOrUpdateRole(guildId, role)
+        }
+    }
+
+    private fun _createOrUpdateRole(guildId: Snowflake, role: DiscordRole) = DiscordGuildRoles.insertOrUpdate(DiscordGuildRoles.guildId, DiscordGuildRoles.roleId) {
+        it[DiscordGuildRoles.guildId] = guildId.toLong()
+        it[DiscordGuildRoles.roleId] = role.id.toLong()
+        it[DiscordGuildRoles.name] = role.name
+        it[DiscordGuildRoles.color] = role.color
+        it[DiscordGuildRoles.hoist] = role.hoist
+        it[DiscordGuildRoles.icon] = role.icon.value
+        it[DiscordGuildRoles.unicodeEmoji] = role.icon.value
+        it[DiscordGuildRoles.position] = role.position
+        it[DiscordGuildRoles.permissions] = role.permissions.code.value.toLong()
+        it[DiscordGuildRoles.managed] = role.managed
+        it[DiscordGuildRoles.mentionable] = role.mentionable
+    }
+
+    private suspend fun deleteRole(guildId: Snowflake, roleId: Snowflake) {
+        m.services.transaction {
+            DiscordGuildRoles.deleteWhere {
+                (DiscordGuildRoles.guildId eq guildId.toLong()) and (DiscordGuildRoles.roleId eq roleId.toLong())
+            }
+        }
+    }
+
+    private suspend fun removeGuildData(guildId: Snowflake) {
+        logger.info { "Removing $guildId's cached data..." }
+        m.services.transaction {
+            DiscordGuildRoles.deleteWhere {
+                (DiscordGuildRoles.guildId eq guildId.toLong())
+            }
+        }
+    }
+}

--- a/microservices/discord-gateway-events-processor/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/discordgatewayeventsprocessor/utils/EventAnalyticsTask.kt
+++ b/microservices/discord-gateway-events-processor/src/main/kotlin/net/perfectdreams/loritta/cinnamon/microservices/discordgatewayeventsprocessor/utils/EventAnalyticsTask.kt
@@ -12,6 +12,7 @@ class EventAnalyticsTask(private val m: DiscordGatewayEventsProcessor) : Runnabl
     override fun run() {
         printStats(m.starboardModule)
         printStats(m.addFirstToNewChannelsModule)
+        printStats(m.discordCacheModule)
     }
 
     private fun printStats(module: ProcessDiscordEventsModule) {

--- a/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/Pudding.kt
+++ b/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/Pudding.kt
@@ -76,6 +76,7 @@ import net.perfectdreams.loritta.cinnamon.pudding.tables.TrackedCorreiosPackages
 import net.perfectdreams.loritta.cinnamon.pudding.tables.UserAchievements
 import net.perfectdreams.loritta.cinnamon.pudding.tables.UserSettings
 import net.perfectdreams.loritta.cinnamon.pudding.tables.UsersFollowingCorreiosPackages
+import net.perfectdreams.loritta.cinnamon.pudding.tables.cache.DiscordGuildRoles
 import net.perfectdreams.loritta.cinnamon.pudding.utils.PuddingTasks
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.DEFAULT_REPETITION_ATTEMPTS
@@ -265,7 +266,8 @@ class Pudding(val hikariDataSource: HikariDataSource, private val database: Data
             TrackedCorreiosPackages,
             UsersFollowingCorreiosPackages,
             TrackedCorreiosPackagesEvents,
-            PendingImportantNotifications
+            PendingImportantNotifications,
+            DiscordGuildRoles
         )
 
         if (schemas.isNotEmpty())

--- a/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/tables/cache/DiscordGuildRoles.kt
+++ b/pudding/client/src/main/kotlin/net/perfectdreams/loritta/cinnamon/pudding/tables/cache/DiscordGuildRoles.kt
@@ -1,0 +1,21 @@
+package net.perfectdreams.loritta.cinnamon.pudding.tables.cache
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+
+object DiscordGuildRoles : LongIdTable() {
+    val guildId = long("guild").index()
+    val roleId = long("role").index()
+    val name = text("name")
+    val color = integer("color")
+    val hoist = bool("hoist")
+    val icon = text("icon").nullable()
+    val unicodeEmoji = text("unicode_emoji").nullable()
+    val position = integer("position")
+    val permissions = long("permissions")
+    val managed = bool("managed")
+    val mentionable = bool("mentionable")
+
+    init {
+        index(true, guildId, roleId)
+    }
+}

--- a/resources/languages/en/commands/user.yml
+++ b/resources/languages/en/commands/user.yml
@@ -28,3 +28,47 @@ banner:
 
   options:
     user: "The user that you want to steal... I mean, view, their banner (*/ω＼*)"
+
+info:
+  infoAboutTheUser: "User Information"
+  infoAboutTheMember: "Member Information"
+  infoAboutTheApplication: "Application Information"
+  interestingTidbits: "Interesting Tidbits"
+
+  user:
+    discordId: "Discord ID"
+    discordTag: "Discord Tag"
+    accountCreationDate: "Account Creation Date"
+
+  member:
+    accountJoinDate: "Account Join Date"
+    timedOutUntil: "Timed Out Until"
+    # The member isn't able to talk in the server? Ask them to check if their device's clock is correct
+    timeoutTip: "The member can't talk on the server? Ask him to check that their device's clock is correct!"
+    boostingSince: "Boosting the server since"
+    highestRole: "Highest role"
+    completedMembershipScreening: "Completed Membership Screening"
+    isTimedOut: "Timed Out"
+    memberPermissions: "Member Permissions"
+    roles: "Roles"
+    permissions: "Permissions"
+
+  application:
+    supportGuildId: "Support Server ID"
+    tags: "Tags"
+    slug: "Slug" #Slug in a SEO context, not the animal
+    addToServer: "Add to Server"
+    termsOfService: "Terms of Service"
+    privacyPolicy: "Privacy Policy"
+
+    public: "Public"
+    requiresOAuth2CodeGrant: "Requires OAuth2 Code Grant"
+    usesInteractionsOverHttp: "Uses Interactions over HTTP"
+    intentGatewayPresences: "Gateway Presences Intent"
+    intentGuildMembers: "Guild Members Intent"
+    intentMessageContent: "Message Content Intent"
+    publicKey: "Public Key for HTTP Requests Verification"
+    noMatchingApplicationFound: "I could not find the application information of this bot... Probably the bot was created so long ago that the application ID differs from the bot ID! (Yeah... back in the day it worked like that)"
+
+  viewUserInfo: "View info" #Shown when right-clicking a user
+


### PR DESCRIPTION
This commit adds the `/user info` command and the "View information" user command.

This also adds roles entity caching on the database, because `/user info` requires it for the:
* Role Position
* Role Color

I'm still not sure if this will work, but hey! Better test it out and see what happens right? At least if the caching system breaks, the command should still work without any issues since it isn't required for it to work.