### PR TITLE
Hyphenate Slash Command Labels

### DIFF
--- a/resources/languages/en/commands/aboutme.yml
+++ b/resources/languages/en/commands/aboutme.yml
@@ -1,4 +1,4 @@
-label: "aboutme"
+label: "about-me"
 description: "Change the \"About Me\" section of your profile to make it feel like you"
 successfullyChanged: "Your about me message was changed to `{aboutMe}`!"
 options:

--- a/resources/languages/en/commands/attackonheart.yml
+++ b/resources/languages/en/commands/attackonheart.yml
@@ -1,2 +1,2 @@
-label: "attackonheart"
+label: "attack-on-heart"
 description: "Make an video of Reiner Braun being frightned by an image of your choice!"

--- a/resources/languages/en/commands/betcoinflipglobal.yml
+++ b/resources/languages/en/commands/betcoinflipglobal.yml
@@ -1,5 +1,5 @@
 label: "global"
-discordOldDiscordAppWorkaroundLabel: "coinflipglobal"
+discordOldDiscordAppWorkaroundLabel: "coin-flip-global"
 description: "The classic \"flip a coin and see on what side it will be!\", but now with sonhos! I don't take responsibility if you lose everything with bets"
 invalidQuantity: "You used an invalid sonhos quantity! Valid quantities: {validQuantities}"
 

--- a/resources/languages/en/commands/bobburningpaper.yml
+++ b/resources/languages/en/commands/bobburningpaper.yml
@@ -1,2 +1,2 @@
-label: "bobburningpaper"
+label: "bob-burning-paper"
 description: "Why throw dumb images in the trash, when you can use it as firewood?"

--- a/resources/languages/en/commands/brmemes.yml
+++ b/resources/languages/en/commands/brmemes.yml
@@ -37,7 +37,7 @@ ednaldo:
     description: "Look! Our beloved god Ednaldo Pereira is trying to show us something amazing on his flag! Let's check it out!"
 
 cortesflow:
-  label: "cortesflow"
+  label: "cortes-flow"
   description: "Salve salve família, make your own Cortes do Flow thumbnails with your own text!"
   thumbnails:
     arthurBenozzatiSmile: "Arthur Benozzati Smiling"
@@ -76,7 +76,7 @@ sam:
       sam3: "Logo sarrada in the air"
 
 canelladvd:
-  label: "canelladvd"
+  label: "canella-dvd"
   description: "Make Matheus Canella hold one of the best DVDs of the world, for only R$ 1.95! (arr dollar sign one dot ninety and five brazilian reais!!!)" #References this video: https://youtu.be/c3f7uSpnrhk
 
 cepo:
@@ -84,9 +84,9 @@ cepo:
   description: "Destroy someone, Gugu Gaiteiro style!"
 
 briggscover:
-  label: "briggscover"
+  label: "briggs-cover"
   description: "Look! @GuilhermeBriggs bought a new game and is showing off to everyone!"
 
 romerobritto:
-  label: "romerobritto"
+  label: "romero-britto"
   description: "Make Romero Britto paint your amazing art!"

--- a/resources/languages/en/commands/buckshirt.yml
+++ b/resources/languages/en/commands/buckshirt.yml
@@ -1,2 +1,2 @@
-label: "buckshirt"
+label: "buck-shirt"
 description: "Put a new stylish design in Buck Dewey's shirt. Create a new fashion in Beach City!"

--- a/resources/languages/en/commands/carlyaaah.yml
+++ b/resources/languages/en/commands/carlyaaah.yml
@@ -1,2 +1,2 @@
-label: "carlyaaah"
+label: "carly-aaah"
 description: "\"We lost iCarly.com and someone else already bought it... somebody named \"Amanda Valdez\"\""

--- a/resources/languages/en/commands/coinflip.yml
+++ b/resources/languages/en/commands/coinflip.yml
@@ -1,4 +1,4 @@
-label: "coinflip"
+label: "coin-flip"
 description: "Let me flip a coin and see if it will land on heads or tails! Perfect to find out who will go first in a soccer match"
 heads: "Heads"
 tails: "Tails"

--- a/resources/languages/en/commands/colorinfo.yml
+++ b/resources/languages/en/commands/colorinfo.yml
@@ -1,4 +1,4 @@
-label: "colorinfo"
+label: "color-info"
 description: "View details about a color"
 analogous: "Analogous"
 complementary: "Complementary"

--- a/resources/languages/en/commands/discordping.yml
+++ b/resources/languages/en/commands/discordping.yml
@@ -1,2 +1,2 @@
-label: "discordping"
+label: "discord-ping"
 description: "When you receive a stupid Discord notification"

--- a/resources/languages/en/commands/drawnmask.yml
+++ b/resources/languages/en/commands/drawnmask.yml
@@ -1,4 +1,4 @@
-label: "drawnmask"
+label: "drawn-mask"
 description: "Illustrator, Animation, YouTuber... and in his free time enslaved so we can have their illustrations here!"
 
 atendente:

--- a/resources/languages/en/commands/fansexplaining.yml
+++ b/resources/languages/en/commands/fansexplaining.yml
@@ -1,4 +1,4 @@
-label: "fansexplaining"
+label: "fans-explaining"
 description: "Fans explaining stuff about their fandom in a very intense manner"
 options:
   section1Line1: "Text that will show up on the top of the first section"

--- a/resources/languages/en/commands/getoverhere.yml
+++ b/resources/languages/en/commands/getoverhere.yml
@@ -1,2 +1,2 @@
-label: "getoverhere"
+label: "get-over-here"
 description: "\"Get over here!\", pull and kick someone with Scorpion's signature move!"

--- a/resources/languages/en/commands/hungergames.yml
+++ b/resources/languages/en/commands/hungergames.yml
@@ -1,4 +1,4 @@
-label: "hungergames"
+label: "hunger-games"
 description: "Creates a custom simulation of BrantSteele's Hunger Games with the chosen users"
 simulationCreated: "Hunger Games Simulation created! Good luck to all players in the simulation. {hungerGamesLink}"
 options:

--- a/resources/languages/en/commands/lorisign.yml
+++ b/resources/languages/en/commands/lorisign.yml
@@ -1,2 +1,2 @@
-label: "lorisign"
+label: "lori-sign"
 description: "Make me hold a sign showing something cute and interesting!"

--- a/resources/languages/en/commands/markmeta.yml
+++ b/resources/languages/en/commands/markmeta.yml
@@ -1,2 +1,2 @@
-label: "markmeta"
+label: "mark-meta"
 description: "I wonder what's the new Facebook branding Mark Zuckerberg is going to show to us!"

--- a/resources/languages/en/commands/mememaker.yml
+++ b/resources/languages/en/commands/mememaker.yml
@@ -1,4 +1,4 @@
-label: "mememaker"
+label: "meme-maker"
 description: "Add captions to a image, perfect if you want to make that amazing meme that you were dreaming of!"
 options:
   line1: "The text that will be shown on the top of the image"

--- a/resources/languages/en/commands/passingpaper.yml
+++ b/resources/languages/en/commands/passingpaper.yml
@@ -1,2 +1,2 @@
-label: "passingpaper"
+label: "passing-paper"
 description: "\"Hey dude, pass to me the test's cheat sheet!\""

--- a/resources/languages/en/commands/pepedream.yml
+++ b/resources/languages/en/commands/pepedream.yml
@@ -1,2 +1,2 @@
-label: "pepedream"
+label: "pepe-dream"
 description: "When you wake up from an pretty nice dream, and you find out that the dream wasn't real..."

--- a/resources/languages/en/commands/predefinedreasons.yml
+++ b/resources/languages/en/commands/predefinedreasons.yml
@@ -1,1 +1,1 @@
-label: "predefinedreasons"
+label: "predefined-reasons"

--- a/resources/languages/en/commands/riptv.yml
+++ b/resources/languages/en/commands/riptv.yml
@@ -1,2 +1,2 @@
-label: "riptv"
+label: "rip-tv"
 description: "You know that feeling when you are angry after watching something in your TV, and you want to shoot the screen?"

--- a/resources/languages/en/commands/sadreality.yml
+++ b/resources/languages/en/commands/sadreality.yml
@@ -1,4 +1,4 @@
-label: "sadreality"
+label: "sad-reality"
 description: "Creates a sad reality with members of your server... Yeah, sadly we don't always win."
 notEnoughUsers: "There aren't enough users for me to make a sad reality, sorry..."
 notEnoughUsersPermissionsTip: "I could pull users from the server's recent messages, but for that you need to give me permission to read the channel's message history!"

--- a/resources/languages/en/commands/sonic.yml
+++ b/resources/languages/en/commands/sonic.yml
@@ -1,10 +1,10 @@
 label: "sonic"
 knuxthrow:
-  label: "knuxthrow"
+  label: "knux-throw"
   description: "Don't touch the Master Emerald! Make Knuckles throw something very far away!"
 
 maniatitlecard:
-  label: "maniatitlecard"
+  label: "mania-title-card"
   description: "Make your own custom zone title card in Sonic Mania's style!"
 
   options:
@@ -12,5 +12,5 @@ maniatitlecard:
     line2: "The second line that will be on the title card"
 
 studiopolistv:
-  label: "studiopolistv"
+  label: "studiopolis-tv"
   description: "I wonder what wonderful and interesting thing Dr. Eggman is broadcasting in his Egg TV channel"

--- a/resources/languages/en/commands/soundbox.yml
+++ b/resources/languages/en/commands/soundbox.yml
@@ -1,4 +1,4 @@
-label: "soundbox"
+label: "sound-box"
 description: "Spice up your voice channel conversations with cool sound effects!"
 
 falatron:

--- a/resources/languages/en/commands/summon.yml
+++ b/resources/languages/en/commands/summon.yml
@@ -1,6 +1,6 @@
 label: "summon"
 tiodopave:
-  label: "tiodopavê"
+  label: "tio-do-pavê"
   description: "Is it to see or to eat?"
 faustao:
   label: "faustão"

--- a/resources/languages/en/commands/terminatoranime.yml
+++ b/resources/languages/en/commands/terminatoranime.yml
@@ -1,4 +1,4 @@
-label: "terminatoranime"
+label: "terminator-anime"
 description: "Trying to hide from your fears. Art made by @tonmoh"
 
 options:

--- a/resources/languages/en/commands/tobecontinued.yml
+++ b/resources/languages/en/commands/tobecontinued.yml
@@ -1,2 +1,2 @@
-label: "tobecontinued"
+label: "to-be-continued"
 description: "*You start listening Roundabout playing in the background*"

--- a/resources/languages/en/commands/undertale.yml
+++ b/resources/languages/en/commands/undertale.yml
@@ -1,6 +1,6 @@
 label: "undertale"
 textbox:
-  label: "textbox"
+  label: "text-box"
   description: "Create your own Undertale/DELTARUNE text box with your own custom text!"
   descriptionGame: "Create your own Undertale/DELTARUNE text box with your own custom text and portraits from Undertale/DELTARUNE!"
   descriptionCustom: "Create your own Undertale/DELTARUNE text box with your own custom text and image!"

--- a/resources/languages/en/commands/wolverineframe.yml
+++ b/resources/languages/en/commands/wolverineframe.yml
@@ -1,2 +1,2 @@
-label: "wolverineframe"
+label: "wolverine-frame"
 description: "When you look at old photos and you miss the good times of the past, the nostalgia of the things that we lived..."


### PR DESCRIPTION
Wait until snek fixes hyphenated command suggestions (Example: When using `/profile aboutme`, it should suggest `/profile about-me`, currently it doesn't)

This would require manually PATCHing the commands to avoid replacing the current command IDs due to the label change, however this is not a huuuge problem.